### PR TITLE
fix paths for windows

### DIFF
--- a/src/Controller/Component/TestRunnerComponent.php
+++ b/src/Controller/Component/TestRunnerComponent.php
@@ -19,7 +19,9 @@ class TestRunnerComponent extends Component {
 
 		$command = $this->getCommand();
 		$command .= ' ' . $file;
-		exec('cd ' . ROOT . ' && ' . $command, $output, $res);
+		$command = str_replace(['/', '\\'], DS, $command);
+		chdir(ROOT);
+		exec($command, $output, $res);
 
 		$result = [
 			'command' => $command,
@@ -42,15 +44,19 @@ class TestRunnerComponent extends Component {
 	public function coverage($file, $name, $type, $force = false) {
 		$command = $this->getCommand();
 
-		$testFile = ROOT . DS . 'webroot/coverage/src/' . $type . '/' . $name . '.php.html';
+		$testFile = ROOT . DS . 'webroot/coverage/' . $name . '.php.html';
+		$testFile = str_replace(['/', '\\'], DS, $testFile);
 
 		$command .= ' ' . $file;
 		$command .= ' --log-junit webroot/coverage/unitreport.xml --coverage-html webroot/coverage --coverage-clover webroot/coverage/coverage.xml --whitelist src/' . $type . '/' . $name . '.php';
+		$command = str_replace(['/', '\\'], DS, $command);
+
 		if (!file_exists($testFile) || $force) {
-			exec('cd ' . ROOT . ' && ' . $command, $output, $res);
+			chdir(ROOT);
+			exec($command, $output, $res);
 		}
 
-		$url = str_replace('\\', '/', '/coverage/src/' . $type . '/' . $name . '.php.html');
+		$url = str_replace('\\', '/', '/coverage/' . $name . '.php.html');
 
 		$output = <<<HTML
 <h2>Coverage-Result</h2>


### PR DESCRIPTION
the paths now work for windows (dunno if this works for linux but it should)
all slashes are replaced before running commands (so `\` and `/`) with `DS`
also the coverage, when you run phpunit for a single file, the coverage file wont be in the same directory structure anymore