### PR TITLE
Keep it simple with the Flash component

### DIFF
--- a/src/Controller/TestCasesController.php
+++ b/src/Controller/TestCasesController.php
@@ -214,7 +214,7 @@ class TestCasesController extends AppController {
 			$this->Flash->error('Error code ' . $return . ': ' . print_r($output, true) . ' [' . $command . ']');
 		}
 
-		$this->Flash->info(json_encode($output));
+		$this->Flash->success(json_encode($output));
 
 		return $return === 0;
 	}


### PR DESCRIPTION
replace `info()` with `success()` as people don't really have `info.ctp` by default but they should have `error.ctp` and `success.ctp`

these flash elements should also be included as assets btw, along with the layout & the rest
ref: [my plugin with these included](https://github.com/unimatrix/backend/tree/master/src/Template/Element/Flash)