### PR TITLE
remove type

### DIFF
--- a/src/Controller/TestCasesController.php
+++ b/src/Controller/TestCasesController.php
@@ -163,7 +163,7 @@ class TestCasesController extends AppController {
 		$files = $this->TestGenerator->getFiles($paths);
 
 		if ($this->request->is('post')) {
-			if ($this->TestGenerator->generate($this->request->getData('name'), $type, $plugin)) {
+			if ($this->TestGenerator->generate($this->request->getData('name'), $plugin)) {
 				$this->Flash->success('Test case generated.');
 			}
 


### PR DESCRIPTION
no `$type` argument anymore exists
I'm not sure if you need to pass `type` with `$options` or no
https://github.com/dereuromark/cakephp-test-helper/blob/92010c5d935f652b4ddee9d114f1e67596051f0a/src/Controller/Component/TestGeneratorComponent.php#L28