### PR TITLE
Use escapeTitle in link helpers

### DIFF
--- a/templates/Demo/buttons.php
+++ b/templates/Demo/buttons.php
@@ -161,7 +161,7 @@
 		<h3>Basic Links</h3>
 		<p><?php echo $this->Html->link('Simple Link', '#'); ?></p>
 		<p><?php echo $this->Html->link('Link with Class', '#', ['class' => 'btn btn-primary']); ?></p>
-		<p><?php echo $this->Html->link('Link with Icon', '#', ['class' => 'btn btn-secondary', 'escape' => false]); ?></p>
+		<p><?php echo $this->Html->link('Link with Icon', '#', ['class' => 'btn btn-secondary', 'escapeTitle' => false]); ?></p>
 
 		<h3>Links with Confirm</h3>
 		<p><?php echo $this->Html->link('Delete Item', '#', [
@@ -174,7 +174,7 @@
 		<p><?php echo $this->Html->link('External with Icon', 'https://example.com', [
 			'target' => '_blank',
 			'class' => 'btn btn-outline-primary',
-			'escape' => false,
+			'escapeTitle' => false,
 		]); ?> <i class="fas fa-external-link-alt"></i></p>
 	</div>
 

--- a/templates/QueryBuilder/index.php
+++ b/templates/QueryBuilder/index.php
@@ -16,7 +16,7 @@ $this->assign('title', 'SQL to CakePHP Query Builder Converter');
 	<?php echo $this->Html->link(
 		$this->TestHelper->icon('dashboard') . ' Back to Dashboard',
 		['controller' => 'TestHelper', 'action' => 'index'],
-		['escape' => false, 'class' => 'btn btn-sm btn-secondary'],
+		['escapeTitle' => false, 'class' => 'btn btn-sm btn-secondary'],
 	); ?>
 </div>
 
@@ -237,7 +237,7 @@ $examples = [
 								<?php echo $this->Html->link(
 									$this->TestHelper->icon('next') . ' Try It',
 									['?' => ['sql' => $exampleSql]],
-									['escape' => false, 'class' => 'btn btn-sm btn-outline-primary mb-2'],
+									['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary mb-2'],
 								); ?>
 							</div>
 						<?php } ?>

--- a/templates/TestCases/browse.php
+++ b/templates/TestCases/browse.php
@@ -34,7 +34,7 @@ $plugins = Plugin::loaded();
 			<?php echo $this->Html->link(
 				$this->TestHelper->icon('home') . ' TestCase',
 				['action' => 'browse', '?' => ['namespace' => $namespace]],
-				['escape' => false],
+				['escapeTitle' => false],
 			); ?>
 		</li>
 		<?php foreach ($breadcrumb as $index => $crumb) { ?>
@@ -63,7 +63,7 @@ $plugins = Plugin::loaded();
 		echo $this->Html->link(
 			$this->TestHelper->icon('back') . ' Back',
 			['action' => 'browse', '?' => array_filter(['namespace' => $namespace, 'path' => $parentPath ?: null])],
-			['escape' => false, 'class' => 'btn btn-outline-secondary btn-sm'],
+			['escapeTitle' => false, 'class' => 'btn btn-outline-secondary btn-sm'],
 		);
 		?>
 	</div>

--- a/templates/TestCases/view.php
+++ b/templates/TestCases/view.php
@@ -22,7 +22,7 @@
 			<?php echo $this->Html->link(
 				$this->TestHelper->icon('home') . ' TestCase',
 				['action' => 'browse', '?' => ['namespace' => $namespace]],
-				['escape' => false],
+				['escapeTitle' => false],
 			); ?>
 		</li>
 		<?php foreach ($breadcrumb as $crumb) { ?>
@@ -47,7 +47,7 @@
 	echo $this->Html->link(
 		$this->TestHelper->icon('back') . ' Back to directory',
 		['action' => 'browse', '?' => array_filter(['namespace' => $namespace, 'path' => $parentPath ?: null])],
-		['escape' => false, 'class' => 'btn btn-outline-secondary btn-sm me-2'],
+		['escapeTitle' => false, 'class' => 'btn btn-outline-secondary btn-sm me-2'],
 	);
 	?>
 	<?php echo $this->Html->link(

--- a/templates/TestHelper/index.php
+++ b/templates/TestHelper/index.php
@@ -81,7 +81,7 @@ $this->assign('title', 'Test Helper Dashboard');
 							<?php echo $this->Html->link(
 								$this->TestHelper->icon($type['icon']) . ' ' . $label,
 								['controller' => 'TestCases', 'action' => $type['action'], '?' => ['namespace' => $namespace]],
-								['escape' => false, 'class' => $btnClass],
+								['escapeTitle' => false, 'class' => $btnClass],
 							); ?>
 						</div>
 					<?php } ?>
@@ -93,7 +93,7 @@ $this->assign('title', 'Test Helper Dashboard');
 				<?php echo $this->Html->link(
 					$this->TestHelper->icon('next') . ' Browse Tests',
 					['controller' => 'TestCases', 'action' => 'browse', '?' => ['namespace' => $namespace]],
-					['escape' => false, 'class' => 'btn btn-sm btn-outline-primary'],
+					['escapeTitle' => false, 'class' => 'btn btn-sm btn-outline-primary'],
 				); ?>
 			</div>
 		</div>
@@ -110,7 +110,7 @@ $this->assign('title', 'Test Helper Dashboard');
 			<div class="card-body">
 				<p class="card-text">Convert raw SQL queries (MySQL) into CakePHP Query Builder code. Supports SELECT, INSERT, UPDATE, DELETE with JOINs, WHERE conditions, GROUP BY, ORDER BY, and more.</p>
 				<ul class="list-unstyled">
-					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Open Query Builder Converter', ['controller' => 'QueryBuilder', 'action' => 'index'], ['escape' => false, 'class' => 'btn btn-primary']); ?></li>
+					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Open Query Builder Converter', ['controller' => 'QueryBuilder', 'action' => 'index'], ['escapeTitle' => false, 'class' => 'btn btn-primary']); ?></li>
 				</ul>
 			</div>
 		</div>
@@ -128,7 +128,7 @@ $this->assign('title', 'Test Helper Dashboard');
 			<div class="card-body">
 				<p class="card-text">Check plugin hooks and get improvement suggestions.</p>
 				<ul class="list-unstyled">
-					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Check Plugin Hooks', ['controller' => 'Plugins'], ['escape' => false, 'class' => 'btn btn-sm btn-info text-white']); ?></li>
+					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Check Plugin Hooks', ['controller' => 'Plugins'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-info text-white']); ?></li>
 				</ul>
 			</div>
 		</div>
@@ -143,8 +143,8 @@ $this->assign('title', 'Test Helper Dashboard');
 			<div class="card-body">
 				<p class="card-text">Tools for managing database migrations and snapshots.</p>
 				<ul class="list-unstyled mb-0">
-					<li class="mb-2"><?= $this->Html->link($this->TestHelper->icon('next') . ' Schema Drift Detection', ['controller' => 'Migrations', 'action' => 'driftCheck'], ['escape' => false, 'class' => 'btn btn-sm btn-warning']) ?></li>
-					<li><?= $this->Html->link($this->TestHelper->icon('next') . ' Migration Re-Do', ['controller' => 'Migrations'], ['escape' => false, 'class' => 'btn btn-sm btn-warning']) ?></li>
+					<li class="mb-2"><?= $this->Html->link($this->TestHelper->icon('next') . ' Schema Drift Detection', ['controller' => 'Migrations', 'action' => 'driftCheck'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-warning']) ?></li>
+					<li><?= $this->Html->link($this->TestHelper->icon('next') . ' Migration Re-Do', ['controller' => 'Migrations'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-warning']) ?></li>
 				</ul>
 			</div>
 		</div>
@@ -159,8 +159,8 @@ $this->assign('title', 'Test Helper Dashboard');
 			<div class="card-body">
 				<p class="card-text">Compare and validate your application structure.</p>
 				<ul class="list-unstyled mb-0">
-					<li class="mb-2"><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Compare Models & DB Tables', ['controller' => 'TestComparison'], ['escape' => false, 'class' => 'btn btn-sm btn-danger text-white']); ?></li>
-					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Compare Fixtures vs Tables', ['controller' => 'TestFixtures'], ['escape' => false, 'class' => 'btn btn-sm btn-danger text-white']); ?></li>
+					<li class="mb-2"><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Compare Models & DB Tables', ['controller' => 'TestComparison'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-danger text-white']); ?></li>
+					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Compare Fixtures vs Tables', ['controller' => 'TestFixtures'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-danger text-white']); ?></li>
 				</ul>
 			</div>
 		</div>
@@ -177,7 +177,7 @@ $this->assign('title', 'Test Helper Dashboard');
 			<div class="card-body">
 				<p class="card-text">View layout examples and HTML5 element demos.</p>
 				<ul class="list-unstyled">
-					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Layouting and More', ['controller' => 'Demo'], ['escape' => false, 'class' => 'btn btn-sm btn-secondary text-white']); ?></li>
+					<li><?php echo $this->Html->link($this->TestHelper->icon('next') . ' Layouting and More', ['controller' => 'Demo'], ['escapeTitle' => false, 'class' => 'btn btn-sm btn-secondary text-white']); ?></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
Using `'escape' => false` on `Html->link` / `Form->postLink` / `Paginator` helpers also disables HTML escaping of attributes (URL, class, title attr), not just the title text. The narrower `'escapeTitle' => false` keeps attribute escaping on while still allowing the icon HTML in the title.

17 call sites updated across 5 admin templates:
- `templates/TestCases/view.php` (2)
- `templates/TestCases/browse.php` (2)
- `templates/TestHelper/index.php` (9)
- `templates/QueryBuilder/index.php` (2)
- `templates/Demo/buttons.php` (2)

The buttons demo page is updated so the demo demonstrates the recommended option name.

Defense-in-depth — the call sites pass mostly static strings, but keeping the strict default protects against future edits that wire dynamic values into URL/class options.

`templates/Demo/flash_messages.php` is intentionally left untouched: its `'escape' => false` references are inside a flash element data array (not a link helper option) and a code sample in a `<pre>` block.
