### PR TITLE
Harden migrations admin against SQL injection and credential leaks

### DIFF
--- a/src/Controller/Component/MigrationsComponent.php
+++ b/src/Controller/Component/MigrationsComponent.php
@@ -21,16 +21,59 @@ class MigrationsComponent extends Component {
 	 * @return string
 	 */
 	public function getSchema(string $database): string {
-		$dbConfig = ConnectionManager::getConfig('default');
-		$command = 'cd ' . ROOT . ' && mysqldump --host=' . ($dbConfig['host'] ?? 'localhost') . ' --user="' . $dbConfig['username'] . '" --password="' . $dbConfig['password'] . '" --no-data ' . $database;
-		exec($command, $output, $code);
-		if ($code !== 0) {
-			$this->getController()->Flash->error(print_r($output, true));
-		}
-		array_pop($output);
-		$content = trim(implode(PHP_EOL, $output));
+		$dbConfig = ConnectionManager::getConfig('default') ?? [];
+		$host = (string)($dbConfig['host'] ?? 'localhost');
+		$user = (string)($dbConfig['username'] ?? '');
+		$password = (string)($dbConfig['password'] ?? '');
 
-		return $content;
+		// Validate database name as defense in depth: it is also passed unquoted as an
+		// argument to mysqldump and we want to reject anything outside [A-Za-z0-9_].
+		if ($database === '' || !preg_match('/^[A-Za-z0-9_]+$/', $database)) {
+			$this->getController()->Flash->error('Invalid database name: ' . $database);
+
+			return '';
+		}
+
+		$command = 'cd ' . escapeshellarg(ROOT) . ' && mysqldump'
+			. ' --host=' . escapeshellarg($host)
+			. ' --user=' . escapeshellarg($user)
+			. ' --no-data '
+			. escapeshellarg($database);
+
+		// Pass the password via MYSQL_PWD env var so it never appears on the
+		// process command line (visible in `ps`/`/proc`).
+		$descriptors = [
+			0 => ['pipe', 'r'],
+			1 => ['pipe', 'w'],
+			2 => ['pipe', 'w'],
+		];
+		$env = ['MYSQL_PWD' => $password] + $_ENV + $_SERVER;
+		// Restrict to scalar values for proc_open env.
+		$env = array_filter($env, fn ($v): bool => is_scalar($v));
+
+		$process = proc_open($command, $descriptors, $pipes, null, $env);
+		if (!is_resource($process)) {
+			$this->getController()->Flash->error('Could not run mysqldump');
+
+			return '';
+		}
+
+		fclose($pipes[0]);
+		$stdout = (string)stream_get_contents($pipes[1]);
+		fclose($pipes[1]);
+		$stderr = (string)stream_get_contents($pipes[2]);
+		fclose($pipes[2]);
+		$code = proc_close($process);
+
+		if ($code !== 0) {
+			$this->getController()->Flash->error($stderr !== '' ? $stderr : ('mysqldump failed (code ' . $code . ')'));
+		}
+
+		$lines = $stdout === '' ? [] : explode("\n", rtrim($stdout, "\n"));
+		// Drop the trailing "Dump completed on ..." line (timestamp would defeat schema diffs).
+		array_pop($lines);
+
+		return trim(implode(PHP_EOL, $lines));
 	}
 
 	/**

--- a/src/Controller/MigrationsController.php
+++ b/src/Controller/MigrationsController.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
+use InvalidArgumentException;
 use SebastianBergmann\Diff\Differ;
 use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
@@ -56,18 +57,23 @@ class MigrationsController extends TestHelperAppController {
 	 */
 	public function tmpDb() {
 		$dbConfig = ConnectionManager::getConfig('default');
-		$database = $dbConfig['database'] ?? [];
+		$database = $dbConfig['database'] ?? '';
 
 		$tmpDatabase = $database . '_tmp';
+		$this->assertValidIdentifier($tmpDatabase, 'database');
 
 		/** @var \Cake\Database\Connection $connection */
 		$connection = ConnectionManager::get('default');
-		$result = $connection->execute('SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \'' . $tmpDatabase . '\';')->fetch();
+		$result = $connection->execute(
+			'SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?',
+			[$tmpDatabase],
+		)->fetch();
 		if ($result) {
 			return $this->redirect(['action' => 'snapshot']);
 		}
 		if ($this->request->is('post')) {
-			$connection->execute('CREATE DATABASE IF NOT EXISTS ' . $tmpDatabase . ';')->closeCursor();
+			$quoted = $connection->getDriver()->quoteIdentifier($tmpDatabase);
+			$connection->execute('CREATE DATABASE IF NOT EXISTS ' . $quoted)->closeCursor();
 
 			$this->Flash->success('Tmp DB created');
 
@@ -113,7 +119,12 @@ class MigrationsController extends TestHelperAppController {
 				/** @var \Cake\Database\Connection $connection */
 				$connection = ConnectionManager::get('default');
 				$migrationsTable = $this->Migrations->getMigrationTableName();
-				$connection->execute('DELETE FROM ' . $migrationsTable . ' WHERE `migration_name` = "Tmp";')->closeCursor();
+				$this->assertValidIdentifier($migrationsTable, 'migrations table');
+				$quotedTable = $connection->getDriver()->quoteIdentifier($migrationsTable);
+				$connection->execute(
+					'DELETE FROM ' . $quotedTable . ' WHERE migration_name = ?',
+					['Tmp'],
+				)->closeCursor();
 
 				$this->Flash->success('Tmp Migration file created');
 
@@ -166,8 +177,9 @@ class MigrationsController extends TestHelperAppController {
 	 */
 	public function snapshotTest() {
 		$dbConfig = ConnectionManager::getConfig('default');
-		$database = $dbConfig['database'] ?? [];
+		$database = $dbConfig['database'] ?? '';
 		$tmpDatabase = $database . '_tmp';
+		$this->assertValidIdentifier($tmpDatabase, 'database');
 
 		$files = [];
 		$migrationsTmpPath = CONFIG . 'MigrationsTmp';
@@ -177,13 +189,7 @@ class MigrationsController extends TestHelperAppController {
 		}
 
 		if ($this->request->is('post') && $this->request->getData('test')) {
-			$connectionConfig = [
-				'database' => $tmpDatabase,
-			] + $dbConfig;
-			$connectionName = 'tmp';
-			if (!ConnectionManager::getConfig($connectionName)) {
-				ConnectionManager::setConfig($connectionName, $connectionConfig);
-			}
+			$this->ensureTmpConnection($tmpDatabase, $dbConfig);
 
 			/** @var \Cake\Database\Connection $connection */
 			$connection = ConnectionManager::get('tmp');
@@ -192,19 +198,16 @@ class MigrationsController extends TestHelperAppController {
 			$schemaCollection = $connection->getSchemaCollection();
 			$sources = $schemaCollection->listTables();
 			if ($sources) {
-				$tableTruncates = 'DROP TABLE ' . implode(';' . PHP_EOL . 'DROP TABLE ', $sources) . ';';
-
-				$sql = <<<SQL
-SET FOREIGN_KEY_CHECKS = 0;
-
-$tableTruncates
-
-SET FOREIGN_KEY_CHECKS = 1;
-SQL;
-				$connection->execute($sql);
+				$driver = $connection->getDriver();
+				$connection->execute('SET FOREIGN_KEY_CHECKS = 0')->closeCursor();
+				foreach ($sources as $source) {
+					$this->assertValidIdentifier($source, 'table');
+					$connection->execute('DROP TABLE ' . $driver->quoteIdentifier($source))->closeCursor();
+				}
+				$connection->execute('SET FOREIGN_KEY_CHECKS = 1')->closeCursor();
 			}
 
-			$command = 'bin/cake migrations migrate -s MigrationsTmp -c "mysql://root@127.0.0.1/' . $tmpDatabase . '" --no-lock';
+			$command = 'bin/cake migrations migrate -s MigrationsTmp -c tmp --no-lock';
 			exec('cd ' . ROOT . ' && ' . $command, $output, $code);
 			$this->Flash->info(print_r($output, true) . ' (code ' . $code . ')');
 			if ($code === 0) {
@@ -224,8 +227,9 @@ SQL;
 	 */
 	public function seedTest() {
 		$dbConfig = ConnectionManager::getConfig('default');
-		$database = $dbConfig['database'] ?? [];
+		$database = $dbConfig['database'] ?? '';
 		$tmpDatabase = $database . '_tmp';
+		$this->assertValidIdentifier($tmpDatabase, 'database');
 
 		$seeds = [];
 		$seedsPath = CONFIG . 'Seeds';
@@ -235,7 +239,9 @@ SQL;
 		}
 
 		if ($this->request->is('post') && $this->request->getData('test')) {
-			$command = 'bin/cake migrations seed -c "mysql://root@127.0.0.1/' . $tmpDatabase . '"';
+			$this->ensureTmpConnection($tmpDatabase, $dbConfig);
+
+			$command = 'bin/cake migrations seed -c tmp';
 			exec('cd ' . ROOT . ' && ' . $command, $output, $code);
 			$this->Flash->info(print_r($output, true) . ' (code ' . $code . ')');
 			if ($code === 0) {
@@ -299,7 +305,9 @@ SQL;
 			/** @var \Cake\Database\Connection $connection */
 			$connection = ConnectionManager::get('default');
 			$migrationsTable = $this->Migrations->getMigrationTableName();
-			$connection->execute('DELETE FROM ' . $migrationsTable . ' WHERE 1=1')->closeCursor();
+			$this->assertValidIdentifier($migrationsTable, 'migrations table');
+			$quotedTable = $connection->getDriver()->quoteIdentifier($migrationsTable);
+			$connection->execute('DELETE FROM ' . $quotedTable . ' WHERE 1=1')->closeCursor();
 
 			$command = 'bin/cake migrations mark_migrated';
 			exec('cd ' . ROOT . ' && ' . $command, $output, $code);
@@ -431,15 +439,18 @@ SQL;
 				$existingTables = $schemaCollection->listTables();
 
 				if ($existingTables) {
+					$testDriver = $testConnection->getDriver();
 					if ($isMysql) {
 						$testConnection->execute('SET FOREIGN_KEY_CHECKS = 0')->closeCursor();
 						foreach ($existingTables as $table) {
-							$testConnection->execute('DROP TABLE IF EXISTS `' . $table . '`')->closeCursor();
+							$this->assertValidIdentifier($table, 'table');
+							$testConnection->execute('DROP TABLE IF EXISTS ' . $testDriver->quoteIdentifier($table))->closeCursor();
 						}
 						$testConnection->execute('SET FOREIGN_KEY_CHECKS = 1')->closeCursor();
 					} elseif ($isPostgres) {
 						foreach ($existingTables as $table) {
-							$testConnection->execute('DROP TABLE IF EXISTS "' . $table . '" CASCADE')->closeCursor();
+							$this->assertValidIdentifier($table, 'table');
+							$testConnection->execute('DROP TABLE IF EXISTS ' . $testDriver->quoteIdentifier($table) . ' CASCADE')->closeCursor();
 						}
 					}
 				}
@@ -844,6 +855,39 @@ SQL;
 		return $this->response
 			->withType('text/plain')
 			->withStringBody(implode("\n", $lines));
+	}
+
+	/**
+	 * Validate that an identifier (database, table, column name) only contains
+	 * safe characters. Used as a defense-in-depth check before identifiers are
+	 * interpolated into SQL or shell commands.
+	 *
+	 * @param string $identifier The identifier to validate.
+	 * @param string $kind Human-readable kind for the error message.
+	 * @throws \InvalidArgumentException When the identifier contains unsafe characters.
+	 * @return void
+	 */
+	protected function assertValidIdentifier(string $identifier, string $kind = 'identifier'): void {
+		if ($identifier === '' || !preg_match('/^[A-Za-z0-9_]+$/', $identifier)) {
+			throw new InvalidArgumentException(sprintf('Invalid %s name: %s', $kind, $identifier));
+		}
+	}
+
+	/**
+	 * Ensure the dedicated `tmp` connection is configured so migrations and
+	 * seeds can be invoked via `-c tmp` instead of an inline DSN. This avoids
+	 * the previous hardcoded `mysql://root...` connection string.
+	 *
+	 * @param string $tmpDatabase Validated tmp database name.
+	 * @param array<string, mixed> $dbConfig Default connection config to inherit from.
+	 * @return void
+	 */
+	protected function ensureTmpConnection(string $tmpDatabase, array $dbConfig): void {
+		if (ConnectionManager::getConfig('tmp')) {
+			return;
+		}
+		$connectionConfig = ['database' => $tmpDatabase] + $dbConfig;
+		ConnectionManager::setConfig('tmp', $connectionConfig);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Robustness pass on the migrations admin panel. This is a development-only plugin (`require-dev`).

### SQL identifier hardening in `MigrationsController`

The tmp database name, migrations table name, and table names from `listTables()` were concatenated raw into SQL strings (existence checks, `CREATE DATABASE`, `DROP TABLE`, `DELETE FROM`). They originate from controlled config but a typo or unusual environment value would produce broken SQL with confusing errors. Each identifier is now validated against a strict `[A-Za-z0-9_]+` allowlist via a new `assertValidIdentifier()` helper and quoted via the driver's `quoteIdentifier()` before any interpolation. The `INFORMATION_SCHEMA` existence check in `tmpDb()` now uses a parameterized query. Affected actions: `tmpDb()`, `snapshot()`, `snapshotTest()`, `seedTest()`, `confirm()`, `driftCheck()`.

### Drop the hardcoded mysql DSN in `snapshotTest()` / `seedTest()`

The migrate/seed shell commands embedded a fixed `mysql://root...` DSN that ignored the actual `default` connection's host/user/password/port. Broke on DDEV, Docker, CI, anything with a non-root user. Replaced with the dedicated `tmp` connection that `snapshotTest()` already configures; setup is factored into `ensureTmpConnection()` and reused in `seedTest()`. Both commands now run with `-c tmp`.

### Stop leaking the DB password on the `mysqldump` command line

`MigrationsComponent::getSchema()` passed the password as `--password=...`, exposing it in `ps` / `/proc` and breaking on passwords containing shell metacharacters. Replaced `exec()` with `proc_open()` and pass the credential via the `MYSQL_PWD` env var. Host, user, and database are wrapped in `escapeshellarg()`; the database name is allowlist-validated.

### Verification

- `vendor/bin/phpunit` — 242 tests pass, 468 assertions
- `vendor/bin/phpstan analyze` (level 8) — no errors
- `vendor/bin/phpcs src/` — clean
