### PR TITLE
Drop the lone __('Submit') call in TestHelper/index.php

### DIFF
--- a/templates/TestHelper/index.php
+++ b/templates/TestHelper/index.php
@@ -39,7 +39,7 @@ $this->assign('title', 'Test Helper Dashboard');
 					]);
 					?>
 					<div class="mt-3">
-						<?php echo $this->Form->submit(__('Submit'), ['class' => 'btn btn-primary']); ?>
+						<?php echo $this->Form->submit('Submit', ['class' => 'btn btn-primary']); ?>
 					</div>
 				<?php echo $this->Form->end(); ?>
 


### PR DESCRIPTION
## Summary

- Drop the single `__('Submit')` wrapper in `templates/TestHelper/index.php`. This is the only translation call in the plugin's 38 templates — every other button label is a bare string literal (e.g. `Demo/buttons.php`, `Demo/form_elements.php`).

This plugin is a dev-only browser tester; translating one button while the surrounding 37 templates ship in raw English is just inconsistency. Removed the wrapper rather than re-routing to a `test_helper` domain because the plugin doesn't translate anything else and isn't intended for end-user deployment.

## Verification (local)

- phpunit: 242 / 242 (2 pre-existing notices, unrelated)
- phpstan: no errors
- phpcs: clean