### PR TITLE
Sort association audit findings by severity (scan + detail)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,7 @@ Each finding can be opened for detail, including a copy-paste fix:
 
 ![Association audit detail with fix](img/associations_fix.png)
 
-A flat scan lists every finding across all in-scope tables at once:
+A flat scan lists every finding across all in-scope tables at once, ordered worst-first (errors, then warnings, then info), and grouped by table within each severity:
 
 ![Association audit flat scan](img/associations_scan.png)
 

--- a/src/Controller/AssociationsController.php
+++ b/src/Controller/AssociationsController.php
@@ -77,7 +77,8 @@ class AssociationsController extends TestHelperAppController {
 		// implicit junction row carries only a physical name and is re-audited on the
 		// default connection; a same-named table on a non-default connection cannot be
 		// disambiguated from the alias alone (known v1 limitation).
-		$findings = $model ? (new AssociationAuditor())->audit([$model]) : [];
+		$auditor = new AssociationAuditor();
+		$findings = $model ? $auditor->sortFindings($auditor->audit([$model])) : [];
 		$grouped = $this->groupByDirection($findings);
 
 		$this->set(compact('model', 'findings', 'grouped'));
@@ -92,7 +93,8 @@ class AssociationsController extends TestHelperAppController {
 		$includeVendor = (bool)$this->request->getQuery('vendor');
 
 		$tables = (new TableResolver())->tables($includeVendor);
-		$findings = (new AssociationAuditor())->audit($tables);
+		$auditor = new AssociationAuditor();
+		$findings = $auditor->sortFindings($auditor->audit($tables));
 		$totals = $this->totals($findings);
 
 		$this->set(compact('findings', 'totals', 'includeVendor'));
@@ -165,12 +167,11 @@ class AssociationsController extends TestHelperAppController {
 	 * @return string
 	 */
 	protected function worst(?string $current, string $candidate): string {
-		$rank = ['info' => 1, 'warning' => 2, 'error' => 3];
 		if ($current === null) {
 			return $candidate;
 		}
 
-		return ($rank[$candidate] ?? 0) > ($rank[$current] ?? 0) ? $candidate : $current;
+		return (Finding::SEVERITY_RANK[$candidate] ?? 0) > (Finding::SEVERITY_RANK[$current] ?? 0) ? $candidate : $current;
 	}
 
 }

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -123,6 +123,27 @@ class AssociationAuditor {
 	}
 
 	/**
+	 * Order findings worst-first for flat/grouped display: severity (error -> warning ->
+	 * info), then table, then column, then message. audit() emits in phase order, so this
+	 * is what turns the raw list into a stable, triage-friendly one. The message tiebreak
+	 * keeps order content-determined (independent of emission order) when several findings
+	 * share severity/table/column, e.g. multiple unsupported associations on one table.
+	 *
+	 * @param array<\TestHelper\Utility\Association\Finding> $findings
+	 * @return array<\TestHelper\Utility\Association\Finding>
+	 */
+	public function sortFindings(array $findings): array {
+		usort($findings, function (Finding $a, Finding $b): int {
+			return (Finding::SEVERITY_RANK[$b->severity] ?? 0) <=> (Finding::SEVERITY_RANK[$a->severity] ?? 0)
+				?: strcmp($a->table, $b->table)
+				?: strcmp($a->column ?? '', $b->column ?? '')
+				?: strcmp($a->message, $b->message);
+		});
+
+		return $findings;
+	}
+
+	/**
 	 * Resolve the display alias for a physical (connection, table) pair, keeping the
 	 * connection dimension so same-named tables on different connections stay distinct.
 	 *

--- a/src/Utility/Association/Finding.php
+++ b/src/Utility/Association/Finding.php
@@ -47,6 +47,17 @@ class Finding {
 	public const SEVERITY_INFO = 'info';
 
 	/**
+	 * Severity sort weight, highest = most severe. Orders findings worst-first.
+	 *
+	 * @var array<string, int>
+	 */
+	public const SEVERITY_RANK = [
+		self::SEVERITY_ERROR => 3,
+		self::SEVERITY_WARNING => 2,
+		self::SEVERITY_INFO => 1,
+	];
+
+	/**
      * @var string
      */
 	public const LAYER_CONSTRAINT = 'constraint';

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -256,4 +256,84 @@ class AssociationAuditorTest extends TestCase {
 		$this->assertSame([], $findings);
 	}
 
+	/**
+	 * Findings sort worst-first: error, then warning, then info.
+	 *
+	 * @return void
+	 */
+	public function testSortFindingsBySeverity() {
+		$findings = [
+			new Finding('Posts', Finding::DIRECTION_CODE_MISSING, 'looseColumn', Finding::SEVERITY_INFO, 'info'),
+			new Finding('Posts', Finding::DIRECTION_MISMATCH, 'belongsTo', Finding::SEVERITY_ERROR, 'error'),
+			new Finding('Posts', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'warning'),
+		];
+
+		$sorted = $this->auditor->sortFindings($findings);
+
+		$this->assertSame(
+			[Finding::SEVERITY_ERROR, Finding::SEVERITY_WARNING, Finding::SEVERITY_INFO],
+			array_map(fn (Finding $finding): string => $finding->severity, $sorted),
+		);
+	}
+
+	/**
+	 * Within a severity band, findings group by table (alphabetical).
+	 *
+	 * @return void
+	 */
+	public function testSortFindingsSecondaryByTable() {
+		$findings = [
+			new Finding('Zebras', Finding::DIRECTION_MISMATCH, 'belongsTo', Finding::SEVERITY_ERROR, 'msg'),
+			new Finding('Apples', Finding::DIRECTION_MISMATCH, 'belongsTo', Finding::SEVERITY_ERROR, 'msg'),
+			new Finding('Mangos', Finding::DIRECTION_MISMATCH, 'belongsTo', Finding::SEVERITY_ERROR, 'msg'),
+		];
+
+		$sorted = $this->auditor->sortFindings($findings);
+
+		$this->assertSame(
+			['Apples', 'Mangos', 'Zebras'],
+			array_map(fn (Finding $finding): string => $finding->table, $sorted),
+		);
+	}
+
+	/**
+	 * Same severity and table fall back to column order, so output is deterministic
+	 * regardless of audit-phase emission order.
+	 *
+	 * @return void
+	 */
+	public function testSortFindingsTertiaryByColumn() {
+		$findings = [
+			new Finding('Posts', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'msg', 'z_id'),
+			new Finding('Posts', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'msg', 'a_id'),
+		];
+
+		$sorted = $this->auditor->sortFindings($findings);
+
+		$this->assertSame(
+			['a_id', 'z_id'],
+			array_map(fn (Finding $finding): ?string => $finding->column, $sorted),
+		);
+	}
+
+	/**
+	 * Findings sharing severity, table and (null) column fall back to message order, so
+	 * e.g. several unsupported associations on one table stay content-deterministic.
+	 *
+	 * @return void
+	 */
+	public function testSortFindingsFinalTiebreakByMessage() {
+		$findings = [
+			new Finding('Posts', Finding::DIRECTION_UNSUPPORTED, 'belongsToMany', Finding::SEVERITY_INFO, 'Beta unsupported'),
+			new Finding('Posts', Finding::DIRECTION_UNSUPPORTED, 'belongsToMany', Finding::SEVERITY_INFO, 'Alpha unsupported'),
+		];
+
+		$sorted = $this->auditor->sortFindings($findings);
+
+		$this->assertSame(
+			['Alpha unsupported', 'Beta unsupported'],
+			array_map(fn (Finding $finding): string => $finding->message, $sorted),
+		);
+	}
+
 }


### PR DESCRIPTION
## What

Order the Association ↔ DB audit findings **worst-first** in both the flat scan (`/test-helper/associations/scan`) and the per-table detail (`view`).

## Why

`AssociationAuditor::audit()` emits findings in audit-phase order (unsupported associations, then DB inspection failures, then the FK diff, then loose columns). That interleaves severities:

- in the **flat scan**, an `info`-level unsupported finding could lead the list while `error` rows sat in the middle and `info` loose-columns trailed at the bottom — contradicting the `errors → warnings → info` order the totals badges already use;
- in the **detail view**, a section like "Declared, but missing DB constraint" mixes `error` (column absent) and `warning` (no constraint), so a warning could render before an error.

## How

- New pure `AssociationAuditor::sortFindings()`: severity (error → warning → info), then table, then column, then message. The message tiebreak keeps the order content-determined instead of relying on emission order when findings share severity/table/column.
- `scan()` sorts the flat list; `view()` sorts before grouping, so each direction section becomes worst-first while the section order stays semantic.
- Severity weighting centralized in `Finding::SEVERITY_RANK`, reused by the matrix's worst-cell aggregation (removes the duplicated inline rank map).
- Docs note the new ordering on the flat scan.
