### PR TITLE
Add key-type layer to the association audit

### DIFF
--- a/src/Controller/AssociationsController.php
+++ b/src/Controller/AssociationsController.php
@@ -133,9 +133,10 @@ class AssociationsController extends TestHelperAppController {
 	 */
 	protected function groupByDirection(array $findings): array {
 		$grouped = [
-			Finding::DIRECTION_CODE_MISSING => [],
-			Finding::DIRECTION_DB_MISSING => [],
 			Finding::DIRECTION_MISMATCH => [],
+			Finding::DIRECTION_TYPE => [],
+			Finding::DIRECTION_DB_MISSING => [],
+			Finding::DIRECTION_CODE_MISSING => [],
 			Finding::DIRECTION_UNSUPPORTED => [],
 		];
 

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -118,6 +118,7 @@ class AssociationAuditor {
 
 		$findings = array_merge($findings, $this->diffForeignKeys($codeKeys, $dbKeys, $aliasByPhysical));
 		$findings = array_merge($findings, $this->looseColumnFindings($looseColumns, $codeKeys, $this->ignoreColumns(), $aliasByPhysical, $claimedColumns));
+		$findings = array_merge($findings, $this->typeFindings($codeKeys));
 
 		return $findings;
 	}
@@ -283,6 +284,92 @@ class AssociationAuditor {
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Pure key-type layer: compares each declared FK column's type against its referenced
+	 * column's type. Different types are an error; matching non-integer types (e.g. both
+	 * uuid) are info, since integer keys are the ideal. The whole integer family
+	 * (integer/biginteger/smallinteger/tinyinteger) is treated as one bucket, so
+	 * width-only differences like integer vs biginteger are considered in agreement.
+	 *
+	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
+	 * @return array<\TestHelper\Utility\Association\Finding>
+	 */
+	public function typeFindings(array $codeKeys): array {
+		$seen = [];
+		$findings = [];
+
+		foreach ($codeKeys as $fk) {
+			if ($fk->ownerColumnType === null || $fk->referencedColumnType === null) {
+				continue;
+			}
+			// Dedupe reciprocal declarations of the same physical FK.
+			if (isset($seen[$fk->key()])) {
+				continue;
+			}
+			$seen[$fk->key()] = true;
+
+			$ownerBucket = $this->typeBucket($fk->ownerColumnType);
+			$referencedBucket = $this->typeBucket($fk->referencedColumnType);
+
+			if ($ownerBucket !== $referencedBucket) {
+				$findings[] = new Finding(
+					table: $fk->declaringTable ?? $fk->ownerTable,
+					direction: Finding::DIRECTION_TYPE,
+					associationType: $fk->associationType ?? 'belongsTo',
+					severity: Finding::SEVERITY_ERROR,
+					message: sprintf(
+						'Key type mismatch: `%s.%s` (%s) references `%s.%s` (%s).',
+						$fk->ownerTable,
+						$fk->column,
+						$fk->ownerColumnType,
+						$fk->referencedTable,
+						$fk->referencedColumn,
+						$fk->referencedColumnType,
+					),
+					column: $fk->column,
+					target: $fk->referencedTable,
+					layer: Finding::LAYER_TYPE,
+				);
+
+				continue;
+			}
+
+			if ($ownerBucket !== 'integer') {
+				$findings[] = new Finding(
+					table: $fk->declaringTable ?? $fk->ownerTable,
+					direction: Finding::DIRECTION_TYPE,
+					associationType: $fk->associationType ?? 'belongsTo',
+					severity: Finding::SEVERITY_INFO,
+					message: sprintf(
+						'Relation `%s.%s` -> `%s.%s` uses non-integer keys (%s); integer keys are preferred.',
+						$fk->ownerTable,
+						$fk->column,
+						$fk->referencedTable,
+						$fk->referencedColumn,
+						$fk->ownerColumnType,
+					),
+					column: $fk->column,
+					target: $fk->referencedTable,
+					layer: Finding::LAYER_TYPE,
+				);
+			}
+		}
+
+		return $findings;
+	}
+
+	/**
+	 * Collapse the integer family into one bucket; other types keep their own name.
+	 *
+	 * @param string $type Abstract DB type.
+	 * @return string
+	 */
+	protected function typeBucket(string $type): string {
+		$integerFamily = ['integer', 'biginteger', 'smallinteger', 'tinyinteger'];
+
+		return in_array($type, $integerFamily, true) ? 'integer' : $type;
 	}
 
 	/**

--- a/src/Utility/Association/AssociationReader.php
+++ b/src/Utility/Association/AssociationReader.php
@@ -172,6 +172,7 @@ class AssociationReader {
 			return null;
 		}
 
+		$referencedColumn = $bindingKey ?: 'id';
 		$ownerColumns = $this->safeColumns($ownerTable);
 
 		return new ForeignKey(
@@ -179,12 +180,14 @@ class AssociationReader {
 			ownerTable: $ownerTable->getTable(),
 			column: $column,
 			referencedTable: $referenced->getTable(),
-			referencedColumn: $bindingKey ?: 'id',
+			referencedColumn: $referencedColumn,
 			source: ForeignKey::SOURCE_CODE,
 			associationType: $this->type($association),
 			declaringTable: $source->getRegistryAlias(),
 			alias: $association->getName(),
 			columnExists: $ownerColumns === null || in_array($column, $ownerColumns, true),
+			ownerColumnType: $this->safeColumnType($ownerTable, $column),
+			referencedColumnType: $this->safeColumnType($referenced, $referencedColumn),
 		);
 	}
 
@@ -195,6 +198,21 @@ class AssociationReader {
 	protected function safeColumns(Table $table): ?array {
 		try {
 			return $table->getSchema()->columns();
+		} catch (Throwable $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Abstract DB type of a column, or null if the schema/column cannot be resolved.
+	 *
+	 * @param \Cake\ORM\Table $table
+	 * @param string $column
+	 * @return string|null
+	 */
+	protected function safeColumnType(Table $table, string $column): ?string {
+		try {
+			return $table->getSchema()->getColumnType($column);
 		} catch (Throwable $e) {
 			return null;
 		}

--- a/src/Utility/Association/Finding.php
+++ b/src/Utility/Association/Finding.php
@@ -32,6 +32,12 @@ class Finding {
 	public const DIRECTION_UNSUPPORTED = 'unsupported';
 
 	/**
+	 * Key column type observation: a type disagreement (error) or non-integer keys (info).
+     * @var string
+	 */
+	public const DIRECTION_TYPE = 'type';
+
+	/**
      * @var string
      */
 	public const SEVERITY_ERROR = 'error';
@@ -55,6 +61,11 @@ class Finding {
      * @var string
      */
 	public const LAYER_COLUMN = 'column';
+
+	/**
+     * @var string
+     */
+	public const LAYER_TYPE = 'type';
 
 	/**
 	 * @param string $table Table to display this finding under.

--- a/src/Utility/Association/ForeignKey.php
+++ b/src/Utility/Association/ForeignKey.php
@@ -33,6 +33,8 @@ class ForeignKey {
 	 * @param string|null $declaringTable Table whose class declared the association (code-sourced).
 	 * @param string|null $alias Association alias (code-sourced).
 	 * @param bool $columnExists Whether the owner column physically exists (code-sourced).
+	 * @param string|null $ownerColumnType Abstract DB type of the owner column (code-sourced), or null if unresolved.
+	 * @param string|null $referencedColumnType Abstract DB type of the referenced column (code-sourced), or null if unresolved.
 	 */
 	public function __construct(
 		public readonly string $connection,
@@ -45,6 +47,8 @@ class ForeignKey {
 		public readonly ?string $declaringTable = null,
 		public readonly ?string $alias = null,
 		public readonly bool $columnExists = true,
+		public readonly ?string $ownerColumnType = null,
+		public readonly ?string $referencedColumnType = null,
 	) {
 	}
 

--- a/src/Utility/Association/JoinTableResolver.php
+++ b/src/Utility/Association/JoinTableResolver.php
@@ -82,6 +82,8 @@ class JoinTableResolver {
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
 				columnExists: $junctionColumns === null || in_array($sourceForeignKey, $junctionColumns, true),
+				ownerColumnType: $this->safeColumnType($junction, $sourceForeignKey),
+				referencedColumnType: $this->safeColumnType($source, $sourceBindingKey),
 			),
 			new ForeignKey(
 				connection: $junctionConnection,
@@ -94,6 +96,8 @@ class JoinTableResolver {
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
 				columnExists: $junctionColumns === null || in_array($targetForeignKey, $junctionColumns, true),
+				ownerColumnType: $this->safeColumnType($junction, $targetForeignKey),
+				referencedColumnType: $this->safeColumnType($target, $targetBindingKey),
 			),
 		];
 
@@ -143,6 +147,21 @@ class JoinTableResolver {
 	protected function safeColumns(Table $table): ?array {
 		try {
 			return $table->getSchema()->columns();
+		} catch (Throwable $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Abstract DB type of a column, or null if the schema/column cannot be resolved.
+	 *
+	 * @param \Cake\ORM\Table $table
+	 * @param string $column
+	 * @return string|null
+	 */
+	protected function safeColumnType(Table $table, string $column): ?string {
+		try {
+			return $table->getSchema()->getColumnType($column);
 		} catch (Throwable $e) {
 			return null;
 		}

--- a/templates/Associations/view.php
+++ b/templates/Associations/view.php
@@ -12,6 +12,7 @@ $this->assign('title', 'Associations: ' . ($model ?: ''));
 
 $labels = [
 	Finding::DIRECTION_MISMATCH => ['Mismatches', 'danger'],
+	Finding::DIRECTION_TYPE => ['Key column types', 'dark'],
 	Finding::DIRECTION_DB_MISSING => ['Declared, but missing DB constraint', 'warning'],
 	Finding::DIRECTION_CODE_MISSING => ['In DB, but no association', 'info'],
 	Finding::DIRECTION_UNSUPPORTED => ['Not auto-verifiable', 'secondary'],

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -256,4 +256,106 @@ class AssociationAuditorTest extends TestCase {
 		$this->assertSame([], $findings);
 	}
 
+	/**
+	 * Both sides integer: the ideal case, no finding.
+	 *
+	 * @return void
+	 */
+	public function testTypeBothIntegerClean() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'integer')]);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * Integer family width differences (integer vs biginteger) are treated as agreement.
+	 *
+	 * @return void
+	 */
+	public function testTypeIntegerFamilyWidthIsClean() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'biginteger')]);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * Different types are an error.
+	 *
+	 * @return void
+	 */
+	public function testTypeMismatchIsError() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'uuid')]);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_TYPE, $findings[0]->direction);
+		$this->assertSame(Finding::SEVERITY_ERROR, $findings[0]->severity);
+		$this->assertStringContainsString('type mismatch', strtolower($findings[0]->message));
+	}
+
+	/**
+	 * Matching non-integer types (both uuid) are info, since integer is preferred.
+	 *
+	 * @return void
+	 */
+	public function testTypeBothUuidIsInfo() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('uuid', 'uuid')]);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_TYPE, $findings[0]->direction);
+		$this->assertSame(Finding::SEVERITY_INFO, $findings[0]->severity);
+		$this->assertStringContainsString('non-integer', $findings[0]->message);
+	}
+
+	/**
+	 * Unknown types (schema not introspectable) are skipped.
+	 *
+	 * @return void
+	 */
+	public function testTypeNullTypesSkipped() {
+		$findings = $this->auditor->typeFindings([$this->typedKey(null, null)]);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * Reciprocal declarations of the same FK yield a single type finding.
+	 *
+	 * @return void
+	 */
+	public function testTypeReciprocalDeduped() {
+		$keys = [
+			$this->typedKey('uuid', 'uuid', 'belongsTo'),
+			$this->typedKey('uuid', 'uuid', 'hasMany'),
+		];
+
+		$findings = $this->auditor->typeFindings($keys);
+
+		$this->assertCount(1, $findings);
+	}
+
+	/**
+	 * Build a code-sourced ForeignKey carrying owner/referenced column types.
+	 *
+	 * @param string|null $ownerType
+	 * @param string|null $referencedType
+	 * @param string $associationType
+	 * @return \TestHelper\Utility\Association\ForeignKey
+	 */
+	protected function typedKey(?string $ownerType, ?string $referencedType, string $associationType = 'belongsTo'): ForeignKey {
+		return new ForeignKey(
+			connection: 'default',
+			ownerTable: 'posts',
+			column: 'author_id',
+			referencedTable: 'authors',
+			referencedColumn: 'id',
+			source: ForeignKey::SOURCE_CODE,
+			associationType: $associationType,
+			declaringTable: 'Posts',
+			alias: 'Authors',
+			columnExists: true,
+			ownerColumnType: $ownerType,
+			referencedColumnType: $referencedType,
+		);
+	}
+
 }

--- a/tests/TestCase/Utility/Association/AssociationReaderTest.php
+++ b/tests/TestCase/Utility/Association/AssociationReaderTest.php
@@ -69,6 +69,26 @@ class AssociationReaderTest extends TestCase {
 		$this->assertSame('author_id', $key->column);
 		$this->assertSame('authors', $key->referencedTable);
 		$this->assertSame('belongsTo', $key->associationType);
+		// Column types are captured from each side's schema.
+		$this->assertSame('integer', $key->ownerColumnType);
+		$this->assertSame('integer', $key->referencedColumnType);
+	}
+
+	/**
+	 * The reader captures a uuid referenced-key type (for the key-type audit layer).
+	 *
+	 * @return void
+	 */
+	public function testBelongsToCapturesUuidReferencedType() {
+		$this->table('Authors', 'authors', ['id' => ['type' => 'uuid']]);
+		$posts = $this->table('Posts', 'posts', ['id' => ['type' => 'integer'], 'author_id' => ['type' => 'integer']]);
+		$posts->belongsTo('Authors', ['foreignKey' => 'author_id']);
+
+		[$keys] = $this->reader->read($posts);
+
+		$this->assertCount(1, $keys);
+		$this->assertSame('integer', $keys[0]->ownerColumnType);
+		$this->assertSame('uuid', $keys[0]->referencedColumnType);
 	}
 
 	/**

--- a/tests/TestCase/Utility/Association/AssociationReaderTest.php
+++ b/tests/TestCase/Utility/Association/AssociationReaderTest.php
@@ -92,6 +92,30 @@ class AssociationReaderTest extends TestCase {
 	}
 
 	/**
+	 * With no explicit bindingKey, the reader resolves the target's actual primary key
+	 * (not a hard-coded `id`) — verifies the type lookup works for non-`id` PKs.
+	 *
+	 * @return void
+	 */
+	public function testBelongsToResolvesNonIdPrimaryKey() {
+		$authors = $this->getTableLocator()->get('Authors', ['table' => 'authors']);
+		$authors->setSchema([
+			'reference' => ['type' => 'uuid'],
+			'name' => ['type' => 'string'],
+			'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['reference']]],
+		]);
+		$posts = $this->table('Posts', 'posts', ['id' => ['type' => 'integer'], 'author_id' => ['type' => 'integer']]);
+		$posts->belongsTo('Authors', ['foreignKey' => 'author_id']);
+
+		[$keys] = $this->reader->read($posts);
+
+		$this->assertCount(1, $keys);
+		// Referenced column is the real PK `reference`, and its type is read from there.
+		$this->assertSame('reference', $keys[0]->referencedColumn);
+		$this->assertSame('uuid', $keys[0]->referencedColumnType);
+	}
+
+	/**
 	 * hasMany moves the FK onto the target table.
 	 *
 	 * @return void


### PR DESCRIPTION
Follow-up to the association vs DB audit (#44).

## Summary

Adds a key-type layer to the audit. For each declared foreign key it compares the owner column's type against the referenced column's type:

- **different types** (e.g. `integer` referencing `uuid`, `string` ↔ `integer`) → **error** — a real, breakable mismatch
- **matching non-integer types** (both `uuid`, both `string`, ...) → **info** — works, but integer keys are the ideal
- both **integer** → clean

The whole integer family (`integer`/`biginteger`/`smallinteger`/`tinyinteger`) is treated as one bucket, so width-only differences like `integer` vs `biginteger` are considered in agreement and produce nothing. (Deliberate — the intent is "int vs uuid", not "int vs biginteger".)

## Design

Column types are captured at read time from each side's schema — owner and referenced tables, including `belongsToMany` junction columns — and carried on the `ForeignKey` value object. That keeps the new `AssociationAuditor::typeFindings()` pass pure and unit-tested. The referenced column is the association's resolved binding key (the target's real primary key, not a hard-coded `id`), so non-`id` PKs are handled. Reciprocal declarations of one physical FK dedupe to a single finding, and relations whose schema cannot be introspected are skipped rather than misreported.

Findings surface under a new "Key column types" group in the per-table detail view and feed the summary matrix / flat scan like any other finding.
