### PR TITLE
Polish association key-type audit: narrowing, opt-out, dedup

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -20,6 +20,15 @@ return [
 		//     [], // App migrations
 		// ],
 
+		// Fixture/test collector (drives /test-helper/test-fixtures and the comparison tool).
+		// Options merge over the component defaults; the connection is taken from the request.
+		// 'Collector' => [
+		//     'blacklist' => ['DebugKit'], // Plugins to skip when collecting models/fixtures.
+		//     'ignoredTables' => [], // Table classes to ignore.
+		//     'ignoredEntities' => [], // Entity classes to ignore.
+		//     'ignoredDbTables' => ['i18n', 'cake_sessions', 'sessions', '/phinxlog/'], // DB tables to ignore (regex allowed via /.../).
+		// ],
+
 		// Association vs DB foreign-key audit (/test-helper/associations)
 		'associationAudit' => [
 			// Extra `*_id` columns the loose-column layer should ignore (added to the

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -20,6 +20,19 @@ return [
 		//     [], // App migrations
 		// ],
 
+		// Association vs DB foreign-key audit (/test-helper/associations)
+		'associationAudit' => [
+			// Extra `*_id` columns the loose-column layer should ignore (added to the
+			// built-in foreign_id/parent_id/related_id), e.g. polymorphic columns.
+			'ignoreColumns' => [
+				// 'commentable_id',
+			],
+			// Emit the info-level "integer keys are preferred" finding for relations that
+			// use matching non-integer keys (e.g. uuid <-> uuid). Set to false to silence
+			// it on apps that deliberately standardize on uuid/other keys.
+			'preferIntegerKeys' => true,
+		],
+
 		'Linter' => [
 			'tasks' => [
 				// ...

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ Audits whether your declared table associations (`belongsTo`, `hasMany`, `hasOne
 * an association declared in code whose column exists but has no matching DB foreign-key constraint (warning; suggests an `addForeignKey()` migration line)
 * a DB foreign key with no matching association (suggests the `belongsTo`/`hasMany` call)
 * a target/column disagreement between the two
+* a key-type layer compares each declared foreign key's column type against the referenced key: a different type family (e.g. `integer` referencing `uuid`) is an error, an owner key narrower than the referenced key (e.g. `integer` referencing `biginteger`) is a warning, and matching non-integer keys are an info hint that integer keys are preferred (silence the hint with `TestHelper.associationAudit.preferIntegerKeys => false`)
 * a secondary layer flags `*_id` columns that have neither a constraint nor an association (configurable ignore list via `TestHelper.associationAudit.ignoreColumns` for polymorphic columns)
 
 App and first-party plugin tables are scanned by default; vendor tables can be folded in via the toggle.

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -18,6 +18,22 @@ class AssociationAuditor {
 
 	use LocatorAwareTrait;
 
+	/**
+	 * Abstract integer types, narrowest to widest. Treated as one family for key-type
+	 * comparison: same-family widths agree, but an owner narrower than the referenced key
+	 * cannot hold every value, so that direction is flagged.
+	 *
+	 * @var array<string>
+	 */
+	protected const INTEGER_TYPES = ['tinyinteger', 'smallinteger', 'integer', 'biginteger'];
+
+	/**
+	 * Bucket name the integer family collapses to.
+	 *
+	 * @var string
+	 */
+	protected const BUCKET_INTEGER = 'integer';
+
 	protected FixSuggester $fixSuggester;
 
 	protected SchemaIntrospector $schema;
@@ -323,10 +339,14 @@ class AssociationAuditor {
 
 	/**
 	 * Pure key-type layer: compares each declared FK column's type against its referenced
-	 * column's type. Different types are an error; matching non-integer types (e.g. both
-	 * uuid) are info, since integer keys are the ideal. The whole integer family
-	 * (integer/biginteger/smallinteger/tinyinteger) is treated as one bucket, so
-	 * width-only differences like integer vs biginteger are considered in agreement.
+	 * column's type:
+	 *
+	 * - different type families (e.g. integer referencing uuid) are an error;
+	 * - within the integer family, an owner narrower than the referenced key (e.g. integer
+	 *   referencing biginteger) is a warning, since it cannot hold every referenced value
+	 *   (a wider or equal owner is fine);
+	 * - matching non-integer families (e.g. both uuid) are info, since integer keys are the
+	 *   ideal - silenced via `TestHelper.associationAudit.preferIntegerKeys`.
 	 *
 	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
 	 * @return array<\TestHelper\Utility\Association\Finding>
@@ -371,28 +391,72 @@ class AssociationAuditor {
 				continue;
 			}
 
-			if ($ownerBucket !== 'integer') {
+			if ($ownerBucket === static::BUCKET_INTEGER) {
+				$ownerRank = array_search($fk->ownerColumnType, static::INTEGER_TYPES, true);
+				$referencedRank = array_search($fk->referencedColumnType, static::INTEGER_TYPES, true);
+				// Equal or wider owner (or an unknown integer subtype) holds every value.
+				if ($ownerRank === false || $referencedRank === false || $ownerRank >= $referencedRank) {
+					continue;
+				}
+
 				$findings[] = new Finding(
 					table: $fk->declaringTable ?? $fk->ownerTable,
 					direction: Finding::DIRECTION_TYPE,
 					associationType: $fk->associationType ?? 'belongsTo',
-					severity: Finding::SEVERITY_INFO,
+					severity: Finding::SEVERITY_WARNING,
 					message: sprintf(
-						'Relation `%s.%s` -> `%s.%s` uses non-integer keys (%s); integer keys are preferred.',
+						'Key `%s.%s` (%s) is narrower than the referenced key `%s.%s` (%s); it cannot hold every referenced value.',
 						$fk->ownerTable,
 						$fk->column,
+						$fk->ownerColumnType,
 						$fk->referencedTable,
 						$fk->referencedColumn,
-						$fk->ownerColumnType,
+						$fk->referencedColumnType,
 					),
 					column: $fk->column,
 					target: $fk->referencedTable,
 					layer: Finding::LAYER_TYPE,
 				);
+
+				continue;
 			}
+
+			// Matching non-integer keys: integer keys are the ideal, so note it as info
+			// unless the app deliberately standardizes on another key type.
+			if (!$this->preferIntegerKeys()) {
+				continue;
+			}
+
+			$findings[] = new Finding(
+				table: $fk->declaringTable ?? $fk->ownerTable,
+				direction: Finding::DIRECTION_TYPE,
+				associationType: $fk->associationType ?? 'belongsTo',
+				severity: Finding::SEVERITY_INFO,
+				message: sprintf(
+					'Relation `%s.%s` -> `%s.%s` uses non-integer keys (%s); integer keys are preferred.',
+					$fk->ownerTable,
+					$fk->column,
+					$fk->referencedTable,
+					$fk->referencedColumn,
+					$fk->ownerColumnType,
+				),
+				column: $fk->column,
+				target: $fk->referencedTable,
+				layer: Finding::LAYER_TYPE,
+			);
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Whether to emit the info-level "integer keys are preferred" finding for relations
+	 * that use matching non-integer keys. Apps standardized on uuid keys can disable it.
+	 *
+	 * @return bool
+	 */
+	protected function preferIntegerKeys(): bool {
+		return (bool)Configure::read('TestHelper.associationAudit.preferIntegerKeys', true);
 	}
 
 	/**
@@ -402,9 +466,7 @@ class AssociationAuditor {
 	 * @return string
 	 */
 	protected function typeBucket(string $type): string {
-		$integerFamily = ['integer', 'biginteger', 'smallinteger', 'tinyinteger'];
-
-		return in_array($type, $integerFamily, true) ? 'integer' : $type;
+		return in_array($type, static::INTEGER_TYPES, true) ? static::BUCKET_INTEGER : $type;
 	}
 
 	/**

--- a/src/Utility/Association/AssociationReader.php
+++ b/src/Utility/Association/AssociationReader.php
@@ -18,6 +18,8 @@ use Throwable;
  */
 class AssociationReader {
 
+	use SchemaColumnAccessTrait;
+
 	protected JoinTableResolver $joinResolver;
 
 	public function __construct() {
@@ -189,33 +191,6 @@ class AssociationReader {
 			ownerColumnType: $this->safeColumnType($ownerTable, $column),
 			referencedColumnType: $this->safeColumnType($referenced, $referencedColumn),
 		);
-	}
-
-	/**
-	 * @param \Cake\ORM\Table $table
-	 * @return array<string>|null Null when the schema cannot be described.
-	 */
-	protected function safeColumns(Table $table): ?array {
-		try {
-			return $table->getSchema()->columns();
-		} catch (Throwable $e) {
-			return null;
-		}
-	}
-
-	/**
-	 * Abstract DB type of a column, or null if the schema/column cannot be resolved.
-	 *
-	 * @param \Cake\ORM\Table $table
-	 * @param string $column
-	 * @return string|null
-	 */
-	protected function safeColumnType(Table $table, string $column): ?string {
-		try {
-			return $table->getSchema()->getColumnType($column);
-		} catch (Throwable $e) {
-			return null;
-		}
 	}
 
 	/**

--- a/src/Utility/Association/JoinTableResolver.php
+++ b/src/Utility/Association/JoinTableResolver.php
@@ -11,6 +11,8 @@ use Throwable;
  */
 class JoinTableResolver {
 
+	use SchemaColumnAccessTrait;
+
 	/**
 	 * @param \Cake\ORM\Association\BelongsToMany $association
 	 * @return array{0: array<\TestHelper\Utility\Association\ForeignKey>, 1: array<\TestHelper\Utility\Association\Finding>}
@@ -138,33 +140,6 @@ class JoinTableResolver {
 		}
 
 		return $value;
-	}
-
-	/**
-	 * @param \Cake\ORM\Table $table
-	 * @return array<string>|null Null when the schema cannot be described.
-	 */
-	protected function safeColumns(Table $table): ?array {
-		try {
-			return $table->getSchema()->columns();
-		} catch (Throwable $e) {
-			return null;
-		}
-	}
-
-	/**
-	 * Abstract DB type of a column, or null if the schema/column cannot be resolved.
-	 *
-	 * @param \Cake\ORM\Table $table
-	 * @param string $column
-	 * @return string|null
-	 */
-	protected function safeColumnType(Table $table, string $column): ?string {
-		try {
-			return $table->getSchema()->getColumnType($column);
-		} catch (Throwable $e) {
-			return null;
-		}
 	}
 
 }

--- a/src/Utility/Association/SchemaColumnAccessTrait.php
+++ b/src/Utility/Association/SchemaColumnAccessTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TestHelper\Utility\Association;
+
+use Cake\ORM\Table;
+use Throwable;
+
+/**
+ * Schema lookups that never throw: a single misconfigured or non-introspectable table
+ * must not abort the audit. Shared by the code-side readers that build foreign keys from
+ * live ORM tables.
+ */
+trait SchemaColumnAccessTrait {
+
+	/**
+	 * @param \Cake\ORM\Table $table
+	 * @return array<string>|null Null when the schema cannot be described.
+	 */
+	protected function safeColumns(Table $table): ?array {
+		try {
+			return $table->getSchema()->columns();
+		} catch (Throwable $e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Abstract DB type of a column, or null if the schema/column cannot be resolved.
+	 *
+	 * @param \Cake\ORM\Table $table
+	 * @param string $column
+	 * @return string|null
+	 */
+	protected function safeColumnType(Table $table, string $column): ?string {
+		try {
+			return $table->getSchema()->getColumnType($column);
+		} catch (Throwable $e) {
+			return null;
+		}
+	}
+
+}

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -2,6 +2,7 @@
 
 namespace TestHelper\Test\TestCase\Utility\Association;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use TestHelper\Utility\Association\AssociationAuditor;
 use TestHelper\Utility\Association\Finding;
@@ -301,12 +302,42 @@ class AssociationAuditorTest extends TestCase {
 	}
 
 	/**
-	 * Integer family width differences (integer vs biginteger) are treated as agreement.
+	 * A wider owner key than the referenced key (biginteger FK -> integer PK) holds every
+	 * referenced value, so it is clean.
 	 *
 	 * @return void
 	 */
-	public function testTypeIntegerFamilyWidthIsClean() {
+	public function testTypeWiderOwnerIntegerIsClean() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('biginteger', 'integer')]);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * A narrower owner key than the referenced key (integer FK -> biginteger PK) cannot
+	 * hold every referenced value, so it is a warning.
+	 *
+	 * @return void
+	 */
+	public function testTypeNarrowerOwnerIntegerIsWarning() {
 		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'biginteger')]);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_TYPE, $findings[0]->direction);
+		$this->assertSame(Finding::SEVERITY_WARNING, $findings[0]->severity);
+		$this->assertStringContainsString('narrower', strtolower($findings[0]->message));
+	}
+
+	/**
+	 * The info-level "integer keys are preferred" finding can be silenced via config, for
+	 * apps that deliberately standardize on non-integer (e.g. uuid) keys.
+	 *
+	 * @return void
+	 */
+	public function testTypeNonIntegerInfoSuppressedByConfig() {
+		Configure::write('TestHelper.associationAudit.preferIntegerKeys', false);
+		$findings = $this->auditor->typeFindings([$this->typedKey('uuid', 'uuid')]);
+		Configure::delete('TestHelper.associationAudit.preferIntegerKeys');
 
 		$this->assertSame([], $findings);
 	}


### PR DESCRIPTION
Follow-up to the association key-type audit (#46), bundling the correctness and cleanup items from a deep-dive review.

## Behavior

- **Narrowing warning.** A foreign-key column narrower than the key it references (e.g. an `integer` FK pointing at a `biginteger` primary key) now produces a `warning` — it cannot physically hold every referenced value. A wider or equal owner stays clean, so this only fires on the genuinely risky direction.
- **Opt-out for the info hint.** New `TestHelper.associationAudit.preferIntegerKeys` (default `true`). Apps that deliberately standardize on `uuid` (or other) keys can set it to `false` to silence the per-relation "integer keys are preferred" info finding.

## Cleanup

- Extract the duplicated `safeColumns()` / `safeColumnType()` (identical in `AssociationReader` and `JoinTableResolver`) into a shared `SchemaColumnAccessTrait`.
- Promote the integer-family list and the bucket sentinel to constants on `AssociationAuditor`.

## Docs / config

- Document the key-type layer in `docs/README.md`, including the new config key.
- Add the `associationAudit` section to the config example (`ignoreColumns` was previously read but undocumented).
- Rename `config.dist.php` to `config.example.php` to match the `.example` convention used by the other plugins.

Note: I deliberately did **not** merge `uuid`/`binaryuuid` into one bucket — they are storage-incompatible (char/native vs binary), so flagging a mismatch there is correct, and collapsing them would hide a real problem.
