### PR TITLE
Add controller test coverage (QueryBuilder, Associations)

### DIFF
--- a/tests/TestCase/Controller/AssociationsControllerTest.php
+++ b/tests/TestCase/Controller/AssociationsControllerTest.php
@@ -4,6 +4,7 @@ namespace TestHelper\Test\TestCase\Controller;
 
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\Finding;
 
 /**
  * @uses \TestHelper\Controller\AssociationsController
@@ -13,6 +14,8 @@ class AssociationsControllerTest extends TestCase {
 	use IntegrationTestTrait;
 
 	/**
+	 * The matrix exposes the association-type columns, a per-table grid and severity totals.
+	 *
 	 * @return void
 	 */
 	public function testIndex() {
@@ -22,9 +25,16 @@ class AssociationsControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertResponseContains('Association');
+		$this->assertSame(['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'looseColumn'], $this->viewVariable('columns'));
+		$this->assertIsArray($this->viewVariable('matrix'));
+		$this->assertIsArray($this->viewVariable('tables'));
+		$this->assertSame(['error', 'warning', 'info'], array_keys($this->viewVariable('totals')));
+		$this->assertFalse($this->viewVariable('includeVendor'));
 	}
 
 	/**
+	 * The vendor toggle flows through to the view.
+	 *
 	 * @return void
 	 */
 	public function testIndexIncludeVendor() {
@@ -33,9 +43,12 @@ class AssociationsControllerTest extends TestCase {
 		$this->get(['plugin' => 'TestHelper', 'controller' => 'Associations', 'action' => 'index', '?' => ['vendor' => 1]]);
 
 		$this->assertResponseCode(200);
+		$this->assertTrue($this->viewVariable('includeVendor'));
 	}
 
 	/**
+	 * The flat scan exposes a findings list and severity totals.
+	 *
 	 * @return void
 	 */
 	public function testScan() {
@@ -44,9 +57,13 @@ class AssociationsControllerTest extends TestCase {
 		$this->get(['plugin' => 'TestHelper', 'controller' => 'Associations', 'action' => 'scan']);
 
 		$this->assertResponseCode(200);
+		$this->assertIsArray($this->viewVariable('findings'));
+		$this->assertSame(['error', 'warning', 'info'], array_keys($this->viewVariable('totals')));
 	}
 
 	/**
+	 * Without a model the detail page renders empty (no findings, all direction groups empty).
+	 *
 	 * @return void
 	 */
 	public function testViewWithoutModel() {
@@ -55,6 +72,26 @@ class AssociationsControllerTest extends TestCase {
 		$this->get(['plugin' => 'TestHelper', 'controller' => 'Associations', 'action' => 'view']);
 
 		$this->assertResponseCode(200);
+		$this->assertSame([], $this->viewVariable('findings'));
+		$this->assertArrayHasKey(Finding::DIRECTION_MISMATCH, $this->viewVariable('grouped'));
+	}
+
+	/**
+	 * With a model the detail page audits it and groups findings by direction.
+	 *
+	 * @return void
+	 */
+	public function testViewWithModel() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'Associations', 'action' => 'view', 'Posts']);
+
+		$this->assertResponseCode(200);
+		$this->assertSame('Posts', $this->viewVariable('model'));
+		$grouped = $this->viewVariable('grouped');
+		$this->assertArrayHasKey(Finding::DIRECTION_MISMATCH, $grouped);
+		$this->assertArrayHasKey(Finding::DIRECTION_TYPE, $grouped);
+		$this->assertArrayHasKey(Finding::DIRECTION_DB_MISSING, $grouped);
 	}
 
 }

--- a/tests/TestCase/Controller/QueryBuilderControllerTest.php
+++ b/tests/TestCase/Controller/QueryBuilderControllerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Controller;
+
+use Cake\TestSuite\IntegrationTestTrait;
+use Cake\TestSuite\TestCase;
+
+/**
+ * @uses \TestHelper\Controller\QueryBuilderController
+ */
+class QueryBuilderControllerTest extends TestCase {
+
+	use IntegrationTestTrait;
+
+	/**
+	 * The empty form renders with no result and no error.
+	 *
+	 * @return void
+	 */
+	public function testIndexEmpty() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'QueryBuilder', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$this->assertSame('', $this->viewVariable('sqlQuery'));
+		$this->assertNull($this->viewVariable('result'));
+		$this->assertNull($this->viewVariable('error'));
+	}
+
+	/**
+	 * SQL passed via the query string (the "Try It" links) is parsed and converted.
+	 *
+	 * @return void
+	 */
+	public function testIndexConvertsSqlFromQueryString() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'QueryBuilder',
+			'action' => 'index',
+			'?' => ['sql' => 'SELECT id, title FROM posts'],
+		]);
+
+		$this->assertResponseCode(200);
+		$result = $this->viewVariable('result');
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('code', $result);
+		$this->assertArrayHasKey('parsed', $result);
+		$this->assertNotEmpty($result['code']);
+		$this->assertNull($this->viewVariable('error'));
+	}
+
+	/**
+	 * A posted query is parsed using the chosen dialect and converted to builder code.
+	 *
+	 * @return void
+	 */
+	public function testIndexConvertsPostedSql() {
+		$this->disableErrorHandlerMiddleware();
+
+		$this->post(
+			['plugin' => 'TestHelper', 'controller' => 'QueryBuilder', 'action' => 'index'],
+			['sql_query' => 'SELECT id, title FROM posts', 'dialect' => 'mysql'],
+		);
+
+		$this->assertResponseCode(200);
+		$result = $this->viewVariable('result');
+		$this->assertIsArray($result);
+		$this->assertNotEmpty($result['code']);
+		$this->assertSame('mysql', $this->viewVariable('dialect'));
+	}
+
+	/**
+	 * Unparseable SQL surfaces an error and a flash message instead of throwing.
+	 *
+	 * @return void
+	 */
+	public function testIndexInvalidSqlShowsError() {
+		$this->enableRetainFlashMessages();
+		$this->disableErrorHandlerMiddleware();
+
+		$this->post(
+			['plugin' => 'TestHelper', 'controller' => 'QueryBuilder', 'action' => 'index'],
+			['sql_query' => 'not a valid query'],
+		);
+
+		$this->assertResponseCode(200);
+		$this->assertNull($this->viewVariable('result'));
+		$this->assertNotNull($this->viewVariable('error'));
+		$this->assertFlashElement('flash/error');
+	}
+
+}


### PR DESCRIPTION
Raises controller test coverage from status-code smoke checks toward real behavioral assertions, starting with the biggest gap.

## QueryBuilderController (was untested)

`QueryBuilderController` had no test at all. New `QueryBuilderControllerTest` covers:

- the empty form (no result, no error),
- SQL passed via the query string (the "Try It" links),
- a posted query with an explicit dialect,
- unparseable SQL surfacing an `error` view variable + an error flash instead of throwing.

This exercises the full parse → generate path and the catch branch.

## AssociationsController (was smoke-only)

The existing tests only asserted a 200. They now assert the actual view state:

- `index`: the association-type columns, the matrix grid, and the `error/warning/info` totals;
- `scan`: the findings list and totals;
- `view`: the per-direction grouping, including drilling into a model.

These exercise `buildMatrix()`, `totals()`, `rowsFromFindings()` and `groupByDirection()` rather than just routing.

The remaining controllers still have smoke-only tests; deepening those (some shell out to commands and need mocking) can follow in further passes.
