### PR TITLE
Add behavior test coverage for Migrations and TestCases features

### DIFF
--- a/tests/TestCase/Controller/Component/MigrationsComponentTest.php
+++ b/tests/TestCase/Controller/Component/MigrationsComponentTest.php
@@ -4,11 +4,21 @@ namespace TestHelper\Test\TestCase\Controller\Component;
 
 use Cake\Controller\ComponentRegistry;
 use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\Datasource\ConnectionManager;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
+use ReflectionClass;
 use TestHelper\Controller\Component\MigrationsComponent;
 
 class MigrationsComponentTest extends TestCase {
+
+	/**
+	 * @var array<string>
+	 */
+	protected array $fixtures = [
+		'plugin.TestHelper.Posts',
+	];
 
 	protected MigrationsComponent $component;
 
@@ -19,6 +29,15 @@ class MigrationsComponentTest extends TestCase {
 		parent::setUp();
 
 		$this->component = new MigrationsComponent(new ComponentRegistry(new Controller(new ServerRequest())));
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		Configure::delete('Migrations.legacyTables');
 	}
 
 	/**
@@ -393,6 +412,495 @@ class MigrationsComponentTest extends TestCase {
 		$this->assertNotContains('phinxlog', $result);
 		$this->assertNotContains('cake_migrations', $result);
 		$this->assertNotContains('cake_seeds', $result);
+	}
+
+	/**
+	 * The detected drift should report no difference when comparing the schema
+	 * of a connection against itself.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasNoDriftAgainstSelf(): void {
+		$connection = ConnectionManager::get('test');
+		$schema = $this->component->getStructuredSchema($connection);
+
+		$drift = $this->component->compareSchemas($schema, $schema);
+
+		$this->assertFalse($this->component->hasDrift($drift));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHasDriftWithIndexDiffs(): void {
+		$drift = [
+			'extra_tables' => [],
+			'missing_tables' => [],
+			'column_diffs' => [],
+			'index_diffs' => [['type' => 'extra', 'table' => 'users', 'index' => 'idx_temp']],
+			'constraint_diffs' => [],
+		];
+
+		$this->assertTrue($this->component->hasDrift($drift));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testHasDriftWithConstraintDiffs(): void {
+		$drift = [
+			'extra_tables' => [],
+			'missing_tables' => [],
+			'column_diffs' => [],
+			'index_diffs' => [],
+			'constraint_diffs' => [['type' => 'missing', 'table' => 'users', 'constraint' => 'fk_author']],
+		];
+
+		$this->assertTrue($this->component->hasDrift($drift));
+	}
+
+	/**
+	 * The extra table entry must list all of its column names.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasExtraTableListsColumns(): void {
+		$expected = [];
+		$actual = [
+			'temp_data' => [
+				'columns' => ['id' => ['type' => 'integer'], 'data' => ['type' => 'text']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['extra_tables']);
+		$this->assertSame(['id', 'data'], $drift['extra_tables'][0]['columns']);
+	}
+
+	/**
+	 * The missing table entry must list all of its column names.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasMissingTableListsColumns(): void {
+		$expected = [
+			'posts' => [
+				'columns' => ['id' => ['type' => 'integer'], 'title' => ['type' => 'string']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+		$actual = [];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['missing_tables']);
+		$this->assertSame(['id', 'title'], $drift['missing_tables'][0]['columns']);
+	}
+
+	/**
+	 * Each tracked column attribute (length, null, default, unsigned, precision,
+	 * scale, autoIncrement) must be detected as a mismatch difference.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasColumnAttributeMismatches(): void {
+		$expected = [
+			'users' => [
+				'columns' => [
+					'amount' => [
+						'type' => 'decimal',
+						'length' => 8,
+						'null' => false,
+						'default' => null,
+						'unsigned' => false,
+						'precision' => 2,
+						'scale' => 1,
+						'autoIncrement' => false,
+					],
+				],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => [
+					'amount' => [
+						'type' => 'decimal',
+						'length' => 10,
+						'null' => true,
+						'default' => '0',
+						'unsigned' => true,
+						'precision' => 4,
+						'scale' => 2,
+						'autoIncrement' => true,
+					],
+				],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['column_diffs']);
+		$this->assertSame('mismatch', $drift['column_diffs'][0]['type']);
+
+		$differences = $drift['column_diffs'][0]['differences'];
+		$this->assertArrayHasKey('length', $differences);
+		$this->assertArrayHasKey('null', $differences);
+		$this->assertArrayHasKey('default', $differences);
+		$this->assertArrayHasKey('unsigned', $differences);
+		$this->assertArrayHasKey('precision', $differences);
+		$this->assertArrayHasKey('scale', $differences);
+		$this->assertArrayHasKey('autoIncrement', $differences);
+		$this->assertArrayNotHasKey('type', $differences);
+
+		$this->assertSame(8, $differences['length']['expected']);
+		$this->assertSame(10, $differences['length']['actual']);
+	}
+
+	/**
+	 * Columns differing only by an attribute outside the compared set must not
+	 * be reported as drift.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasColumnIgnoresUntrackedAttributes(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer', 'collate' => 'utf8_bin']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer', 'collate' => 'latin1_swedish']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertFalse($this->component->hasDrift($drift));
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCompareSchemasMissingIndex(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => ['idx_email' => ['type' => 'index', 'columns' => ['email']]],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['index_diffs']);
+		$this->assertSame('missing', $drift['index_diffs'][0]['type']);
+		$this->assertSame('idx_email', $drift['index_diffs'][0]['index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCompareSchemasIndexMismatch(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => ['idx_name' => ['type' => 'index', 'columns' => ['name']]],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => ['idx_name' => ['type' => 'index', 'columns' => ['name', 'email']]],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['index_diffs']);
+		$this->assertSame('mismatch', $drift['index_diffs'][0]['type']);
+		$this->assertSame('idx_name', $drift['index_diffs'][0]['index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCompareSchemasExtraConstraint(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => ['fk_author' => ['type' => 'foreign', 'columns' => ['author_id']]],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['constraint_diffs']);
+		$this->assertSame('extra', $drift['constraint_diffs'][0]['type']);
+		$this->assertSame('fk_author', $drift['constraint_diffs'][0]['constraint']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCompareSchemasMissingConstraint(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertCount(1, $drift['constraint_diffs']);
+		$this->assertSame('missing', $drift['constraint_diffs'][0]['type']);
+		$this->assertSame('primary', $drift['constraint_diffs'][0]['constraint']);
+	}
+
+	/**
+	 * Multiple kinds of drift across several tables must all be reported in a
+	 * single comparison.
+	 *
+	 * @return void
+	 */
+	public function testCompareSchemasMixedDrift(): void {
+		$expected = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer'], 'email' => ['type' => 'string']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+			'posts' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+		$actual = [
+			'users' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+			'logs' => [
+				'columns' => ['id' => ['type' => 'integer']],
+				'indexes' => [],
+				'constraints' => [],
+			],
+		];
+
+		$drift = $this->component->compareSchemas($expected, $actual);
+
+		$this->assertTrue($this->component->hasDrift($drift));
+		$this->assertCount(1, $drift['missing_tables']);
+		$this->assertSame('posts', $drift['missing_tables'][0]['table']);
+		$this->assertCount(1, $drift['extra_tables']);
+		$this->assertSame('logs', $drift['extra_tables'][0]['table']);
+		$this->assertCount(1, $drift['column_diffs']);
+		$this->assertSame('missing', $drift['column_diffs'][0]['type']);
+		$this->assertSame('email', $drift['column_diffs'][0]['column']);
+	}
+
+	/**
+	 * The structured schema must contain the real columns and constraints of a
+	 * live connection and skip migration bookkeeping tables.
+	 *
+	 * @return void
+	 */
+	public function testGetStructuredSchemaFromConnection(): void {
+		$connection = ConnectionManager::get('test');
+
+		$schema = $this->component->getStructuredSchema($connection);
+
+		$this->assertArrayHasKey('posts', $schema);
+		$this->assertArrayNotHasKey('phinxlog', $schema);
+		$this->assertArrayNotHasKey('cake_migrations', $schema);
+
+		$this->assertArrayHasKey('columns', $schema['posts']);
+		$this->assertArrayHasKey('indexes', $schema['posts']);
+		$this->assertArrayHasKey('constraints', $schema['posts']);
+
+		$this->assertArrayHasKey('id', $schema['posts']['columns']);
+		$this->assertArrayHasKey('title', $schema['posts']['columns']);
+		$this->assertArrayHasKey('primary', $schema['posts']['constraints']);
+	}
+
+	/**
+	 * Volatile column attributes such as comments must be stripped so they do
+	 * not surface as false drift.
+	 *
+	 * @return void
+	 */
+	public function testGetStructuredSchemaStripsComment(): void {
+		$connection = ConnectionManager::get('test');
+
+		$schema = $this->component->getStructuredSchema($connection);
+
+		foreach ($schema['posts']['columns'] as $column) {
+			$this->assertArrayNotHasKey('comment', $column);
+		}
+	}
+
+	/**
+	 * The structured schema must be ordered alphabetically by table name.
+	 *
+	 * @return void
+	 */
+	public function testGetStructuredSchemaIsSortedByTable(): void {
+		$connection = ConnectionManager::get('test');
+
+		$schema = $this->component->getStructuredSchema($connection);
+
+		$tables = array_keys($schema);
+		$sorted = $tables;
+		sort($sorted);
+		$this->assertSame($sorted, $tables);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetApplicationTablesForConnection(): void {
+		$result = $this->component->getApplicationTables('test');
+
+		$this->assertContains('posts', $result);
+		$this->assertNotContains('phinxlog', $result);
+	}
+
+	/**
+	 * Without a legacy flag, the table name is auto-detected from the presence
+	 * of the modern cake_migrations table. The expectation is derived from the
+	 * live schema so the test stays valid regardless of ambient database state.
+	 *
+	 * @return void
+	 */
+	public function testGetMigrationTableNameAutoDetects(): void {
+		Configure::delete('Migrations.legacyTables');
+
+		$tables = ConnectionManager::get('test')->getSchemaCollection()->listTables();
+		$expected = in_array('cake_migrations', $tables, true) ? 'cake_migrations' : 'phinxlog';
+
+		$result = $this->component->getMigrationTableName('test');
+
+		$this->assertSame($expected, $result);
+	}
+
+	/**
+	 * An explicit legacy flag must short-circuit auto-detection.
+	 *
+	 * @return void
+	 */
+	public function testGetMigrationTableNameRespectsLegacyConfigTrue(): void {
+		Configure::write('Migrations.legacyTables', true);
+
+		$result = $this->component->getMigrationTableName('test');
+
+		$this->assertSame('phinxlog', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testGetMigrationTableNameRespectsLegacyConfigFalse(): void {
+		Configure::write('Migrations.legacyTables', false);
+
+		$result = $this->component->getMigrationTableName('test');
+
+		$this->assertSame('cake_migrations', $result);
+	}
+
+	/**
+	 * The detected plugin list must be a sorted, de-duplicated string array.
+	 * Its membership depends on migration bookkeeping tables that may exist on a
+	 * persistent test database, so only the contract is asserted.
+	 *
+	 * @return void
+	 */
+	public function testGetPluginsWithMigrationsForConnection(): void {
+		$result = $this->component->getPluginsWithMigrations('test');
+
+		foreach ($result as $plugin) {
+			$this->assertIsString($plugin);
+		}
+
+		$sorted = $result;
+		sort($sorted);
+		$this->assertSame($sorted, $result);
+		$this->assertSame(array_values(array_unique($result)), $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNormalizeColumnNull(): void {
+		$result = $this->invokeMethod($this->component, 'normalizeColumn', [null]);
+
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testNormalizeColumnStripsComment(): void {
+		$column = ['type' => 'string', 'length' => 255, 'comment' => 'some note'];
+
+		$result = $this->invokeMethod($this->component, 'normalizeColumn', [$column]);
+
+		$this->assertArrayNotHasKey('comment', $result);
+		$this->assertSame('string', $result['type']);
+		$this->assertSame(255, $result['length']);
+	}
+
+	/**
+	 * Helper to invoke protected/private methods.
+	 *
+	 * @param object $object
+	 * @param string $methodName
+	 * @param array<mixed> $parameters
+	 * @return mixed
+	 */
+	protected function invokeMethod(object $object, string $methodName, array $parameters = []): mixed {
+		$method = (new ReflectionClass($object::class))->getMethod($methodName);
+
+		return $method->invokeArgs($object, $parameters);
 	}
 
 }

--- a/tests/TestCase/Controller/MigrationsControllerTest.php
+++ b/tests/TestCase/Controller/MigrationsControllerTest.php
@@ -14,6 +14,16 @@ class MigrationsControllerTest extends TestCase {
 	use IntegrationTestTrait;
 
 	/**
+	 * Whether the Migrations plugin is installed in this environment. When it is
+	 * missing, every action redirects out via the controller's beforeFilter.
+	 *
+	 * @return bool
+	 */
+	protected function migrationsPluginInstalled(): bool {
+		return file_exists(ROOT . DS . 'vendor/cakephp/migrations/composer.json');
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testIndex(): void {
@@ -265,6 +275,116 @@ class MigrationsControllerTest extends TestCase {
 			$this->assertResponseCode(200);
 			$this->assertResponseContains('Order auto-detected');
 			$this->assertResponseContains('To customize the order');
+		}
+	}
+
+	/**
+	 * When the Migrations plugin is missing the beforeFilter must redirect to the
+	 * TestHelper landing page and set an error flash message.
+	 *
+	 * @return void
+	 */
+	public function testIndexRedirectsWithFlashWhenPluginMissing(): void {
+		if ($this->migrationsPluginInstalled()) {
+			$this->markTestSkipped('Migrations plugin is installed; redirect path is not exercised.');
+		}
+
+		$this->enableRetainFlashMessages();
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'Migrations', 'action' => 'index']);
+
+		$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+		$this->assertFlashMessage(__('It seems the Migrations plugin is missing.'));
+		$this->assertFlashElement('flash/error');
+	}
+
+	/**
+	 * A POST to a write action must also be blocked by the beforeFilter redirect
+	 * when the plugin is missing, so no schema changes can be triggered.
+	 *
+	 * @return void
+	 */
+	public function testTmpDbPostRedirectsWhenPluginMissing(): void {
+		if ($this->migrationsPluginInstalled()) {
+			$this->markTestSkipped('Migrations plugin is installed; redirect path is not exercised.');
+		}
+
+		$this->post(['plugin' => 'TestHelper', 'controller' => 'Migrations', 'action' => 'tmpDb'], []);
+
+		$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testSnapshotPostRedirectsWhenPluginMissing(): void {
+		if ($this->migrationsPluginInstalled()) {
+			$this->markTestSkipped('Migrations plugin is installed; redirect path is not exercised.');
+		}
+
+		$this->post(
+			['plugin' => 'TestHelper', 'controller' => 'Migrations', 'action' => 'snapshot'],
+			['generate' => 1],
+		);
+
+		$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testDriftCheckPostRedirectsWhenPluginMissing(): void {
+		if ($this->migrationsPluginInstalled()) {
+			$this->markTestSkipped('Migrations plugin is installed; redirect path is not exercised.');
+		}
+
+		$this->post(
+			['plugin' => 'TestHelper', 'controller' => 'Migrations', 'action' => 'driftCheck'],
+			['action' => 'run_migrations'],
+		);
+
+		$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+	}
+
+	/**
+	 * The connection query parameter must be accepted on driftCheck. With the
+	 * plugin missing it still redirects; with the plugin present it renders.
+	 *
+	 * @return void
+	 */
+	public function testDriftCheckWithConnectionQuery(): void {
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'Migrations',
+			'action' => 'driftCheck',
+			'?' => ['connection' => 'default'],
+		]);
+
+		if ($this->_response->getStatusCode() === 302) {
+			$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+		} else {
+			$this->assertResponseCode(200);
+			$this->assertResponseContains('Schema Drift Detection');
+		}
+	}
+
+	/**
+	 * An unknown export format must fall back to JSON output.
+	 *
+	 * @return void
+	 */
+	public function testDriftCheckExportUnknownFormatFallsBackToJson(): void {
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'Migrations',
+			'action' => 'driftCheck',
+			'?' => ['compare' => '1', 'format' => 'xml'],
+		]);
+
+		if ($this->_response->getStatusCode() === 302) {
+			$this->assertRedirect(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+		} else {
+			$this->assertResponseCode(200);
+			$this->assertContentType('application/json');
 		}
 	}
 

--- a/tests/TestCase/Controller/TestCasesControllerTest.php
+++ b/tests/TestCase/Controller/TestCasesControllerTest.php
@@ -93,4 +93,143 @@ class TestCasesControllerTest extends TestCase {
 		$this->assertResponseCode(200);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testForm(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'form', '?' => ['namespace' => 'app']]);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testMailer(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'mailer', '?' => ['namespace' => 'app']]);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCell(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'cell', '?' => ['namespace' => 'app']]);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testCommandHelper(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'commandHelper', '?' => ['namespace' => 'app']]);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * Listing components for a plugin must surface the plugin's own components
+	 * (exercising the file-listing and existing-test-case detection branch).
+	 *
+	 * @return void
+	 */
+	public function testComponentPluginListsClasses(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'component', '?' => ['namespace' => 'TestHelper']]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Migrations');
+		$this->assertResponseContains('TestGenerator');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBrowse(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'browse']);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testBrowsePlugin(): void {
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestCases', 'action' => 'browse', '?' => ['namespace' => 'TestHelper']]);
+
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * Browsing into an existing subfolder must list the test files it contains.
+	 *
+	 * @return void
+	 */
+	public function testBrowseSubPath(): void {
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'browse',
+			'?' => ['namespace' => 'TestHelper', 'path' => 'Utility'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('ClassResolverTest.php');
+	}
+
+	/**
+	 * A non-existent path must fall back to the base directory with an error
+	 * flash instead of failing.
+	 *
+	 * @return void
+	 */
+	public function testBrowseInvalidPathSetsFlash(): void {
+		$this->enableRetainFlashMessages();
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'browse',
+			'?' => ['namespace' => 'TestHelper', 'path' => 'DoesNotExist'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertFlashMessage(__('Directory not found: {0}', 'DoesNotExist'));
+	}
+
+	/**
+	 * Directory traversal segments in the path must be stripped for safety.
+	 *
+	 * @return void
+	 */
+	public function testBrowseStripsTraversal(): void {
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'browse',
+			'?' => ['namespace' => 'TestHelper', 'path' => '../../../etc'],
+		]);
+
+		// Traversal is stripped so the resolved path collapses to the base dir.
+		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * Viewing a real test file must reflect its test methods in the output.
+	 *
+	 * @return void
+	 */
+	public function testViewListsMethods(): void {
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'view',
+			'?' => ['namespace' => 'TestHelper', 'file' => 'Utility' . DS . 'ClassResolverTest.php'],
+		]);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('testType');
+		$this->assertResponseContains('testSuffix');
+	}
+
 }


### PR DESCRIPTION
Adds real behavior coverage to the Migrations drift-check feature and the TestCases listing/baking feature, both of which previously had only thin smoke tests. Test files only; no production code changed.

## Migrations drift component

Covers the schema-comparison logic that drives drift detection:

- extra / missing / mismatch branches for indexes and constraints (only the index extra and constraint mismatch branches were covered before)
- all tracked column-attribute mismatches (length, null, default, unsigned, precision, scale, autoIncrement) and verification that untracked attributes do not register as drift
- mixed multi-table drift in a single comparison, and comparing a live connection schema against itself (no drift)
- hasDrift returning true for index and constraint diffs
- structured-schema extraction from a real connection: comment stripping, ignored-table filtering, and alphabetical table ordering
- application-table listing for a specific connection
- migration-table-name resolution: auto-detection plus explicit legacy on/off
- normalizeColumn edge cases (null input, comment removal)

Assertions that depend on database state derive their expectations from the live schema, so they remain valid against a persistent test database rather than assuming an empty migration history.

## Migrations controller

Covers the beforeFilter guard that redirects to the landing page with an error flash when the Migrations plugin is absent, including write actions issued via POST, plus the connection query parameter and the unknown-export-format fallback to JSON. These paths assert deterministically when the plugin is missing and fall back to the existing conditional pattern when it is present.

## TestCases controller

Covers the previously untested browse and view actions (app and plugin namespaces, sub-path listing, invalid-path flash, directory-traversal stripping, and method extraction from a real test file) and the remaining bake handlers (form, mailer, cell, command helper), including a plugin-namespace listing that exercises the existing-test-case detection branch.

## Notes on source robustness (not changed here)

While writing the view-action tests: the view action returns early when no file is given or the file is missing, but still renders its template, which expects view variables and produces a 500. The early-return paths set a flash but do not stop rendering. Noting it here since this PR is test-only.
