### PR TITLE
Add topic filter chips to the association flat scan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,7 +90,7 @@ Each finding can be opened for detail, including a copy-paste fix:
 
 ![Association audit detail with fix](img/associations_fix.png)
 
-A flat scan lists every finding across all in-scope tables at once, ordered worst-first (errors, then warnings, then info), and grouped by table within each severity:
+A flat scan lists every finding across all in-scope tables at once, ordered worst-first (errors, then warnings, then info), and grouped by table within each severity. Topic chips at the top (Constraints, Columns, Key types, Not verifiable) toggle whole categories of finding in or out, so you can mute, say, the not-verifiable noise and focus on real constraint problems:
 
 ![Association audit flat scan](img/associations_scan.png)
 

--- a/src/Utility/Association/Finding.php
+++ b/src/Utility/Association/Finding.php
@@ -110,6 +110,17 @@ class Finding {
 	}
 
 	/**
+	 * Coarse subject of the finding, used to group/filter the flat scan: the layer
+	 * (constraint / column / type) for regular findings, or "unsupported" for the
+	 * not-auto-verifiable ones (which carry no meaningful layer).
+	 *
+	 * @return string
+	 */
+	public function topic(): string {
+		return $this->direction === static::DIRECTION_UNSUPPORTED ? static::DIRECTION_UNSUPPORTED : $this->layer;
+	}
+
+	/**
 	 * @return array<string, mixed>
 	 */
 	public function toArray(): array {

--- a/templates/Associations/scan.php
+++ b/templates/Associations/scan.php
@@ -6,6 +6,8 @@
  * @var bool $includeVendor
  */
 
+use TestHelper\Utility\Association\Finding;
+
 $this->assign('title', 'Association ↔ DB Audit: Flat scan');
 
 $rowClass = function (string $severity): string {
@@ -15,6 +17,14 @@ $rowClass = function (string $severity): string {
 		default => '',
 	};
 };
+
+$topicLabels = [
+	Finding::LAYER_CONSTRAINT => 'Constraints',
+	Finding::LAYER_COLUMN => 'Columns',
+	Finding::LAYER_TYPE => 'Key types',
+	Finding::DIRECTION_UNSUPPORTED => 'Not verifiable',
+];
+$topicCounts = array_count_values(array_map(fn (Finding $finding): string => $finding->topic(), $findings));
 ?>
 
 <div class="page-header mb-3">
@@ -29,6 +39,22 @@ $rowClass = function (string $severity): string {
 	<span class="badge bg-warning text-dark fs-6"><?php echo (int)($totals['warning'] ?? 0); ?> warnings</span>
 	<span class="badge bg-info text-dark fs-6"><?php echo (int)($totals['info'] ?? 0); ?> info</span>
 </div>
+
+<?php if ($findings) { ?>
+	<div class="d-flex gap-2 mb-3 flex-wrap align-items-center" id="topicFilter">
+		<span class="text-muted small">Filter by topic:</span>
+		<?php foreach ($topicLabels as $topic => $label) {
+			$count = $topicCounts[$topic] ?? 0;
+			if (!$count) {
+				continue;
+			}
+			?>
+			<button type="button" class="btn btn-sm btn-outline-secondary active topic-chip" data-topic="<?php echo h($topic); ?>" aria-pressed="true">
+				<?php echo h($label); ?> <span class="badge bg-secondary"><?php echo $count; ?></span>
+			</button>
+		<?php } ?>
+	</div>
+<?php } ?>
 
 <?php if (!$findings) { ?>
 	<div class="alert alert-success"><?php echo $this->TestHelper->icon('check'); ?> No mismatches found across all in-scope tables.</div>
@@ -48,7 +74,7 @@ $rowClass = function (string $severity): string {
 			</thead>
 			<tbody>
 				<?php foreach ($findings as $finding) { ?>
-					<tr class="<?php echo $rowClass($finding->severity); ?>">
+					<tr class="<?php echo $rowClass($finding->severity); ?>" data-topic="<?php echo h($finding->topic()); ?>">
 						<td><?php echo h($finding->severity); ?></td>
 						<td><?php echo $this->Html->link(h($finding->table), ['action' => 'view', $finding->table]); ?></td>
 						<td><code><?php echo h($finding->associationType); ?></code></td>
@@ -62,3 +88,30 @@ $rowClass = function (string $severity): string {
 		</table>
 	</div>
 <?php } ?>
+
+<?php $this->append('script'); ?>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+	var filter = document.getElementById('topicFilter');
+	if (!filter) {
+		return;
+	}
+	var rows = document.querySelectorAll('table tbody tr[data-topic]');
+	var off = {};
+	function apply() {
+		rows.forEach(function (row) {
+			row.style.display = off[row.getAttribute('data-topic')] ? 'none' : '';
+		});
+	}
+	filter.querySelectorAll('.topic-chip').forEach(function (chip) {
+		chip.addEventListener('click', function () {
+			var topic = chip.getAttribute('data-topic');
+			off[topic] = !off[topic];
+			chip.classList.toggle('active', !off[topic]);
+			chip.setAttribute('aria-pressed', off[topic] ? 'false' : 'true');
+			apply();
+		});
+	});
+});
+</script>
+<?php $this->end(); ?>

--- a/tests/TestCase/Utility/Association/FindingTest.php
+++ b/tests/TestCase/Utility/Association/FindingTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Utility\Association;
+
+use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\Finding;
+
+class FindingTest extends TestCase {
+
+	/**
+	 * The topic of a normal finding is its layer (constraint / column / type).
+	 *
+	 * @return void
+	 */
+	public function testTopicFromLayer() {
+		$constraint = new Finding('Posts', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'msg', layer: Finding::LAYER_CONSTRAINT);
+		$this->assertSame(Finding::LAYER_CONSTRAINT, $constraint->topic());
+
+		$column = new Finding('Posts', Finding::DIRECTION_COLUMN_MISSING, 'belongsTo', Finding::SEVERITY_ERROR, 'msg', layer: Finding::LAYER_COLUMN);
+		$this->assertSame(Finding::LAYER_COLUMN, $column->topic());
+
+		$type = new Finding('Posts', Finding::DIRECTION_TYPE, 'belongsTo', Finding::SEVERITY_INFO, 'msg', layer: Finding::LAYER_TYPE);
+		$this->assertSame(Finding::LAYER_TYPE, $type->topic());
+	}
+
+	/**
+	 * Unsupported findings get their own topic, regardless of the (default) layer.
+	 *
+	 * @return void
+	 */
+	public function testTopicUnsupported() {
+		$finding = new Finding('Posts', Finding::DIRECTION_UNSUPPORTED, 'belongsToMany', Finding::SEVERITY_INFO, 'msg');
+
+		$this->assertSame(Finding::DIRECTION_UNSUPPORTED, $finding->topic());
+	}
+
+}


### PR DESCRIPTION
Adds topic-based filtering to the association flat scan (`/test-helper/associations/scan`), per the "coarse, layer-based chips, flat scan first" direction.

## What

- `Finding::topic()` — a coarse category derived from the (previously unused) `layer` field: `constraint` / `column` / `type`, or `unsupported` for not-auto-verifiable findings.
- The flat scan renders a chip per present topic (with a count). Clicking a chip toggles that whole category of finding in/out, client-side (vanilla JS, instant, no reload). So you can mute, say, the "Not verifiable" noise and focus on real constraint problems.

## Why

Severity filtering misses the point — the noise is usually a *topic* (loose/not-verifiable, or key-type hints), not a severity. This also finally gives the `layer` field a consumer.

## Notes

- Topic tally is computed in the template from the findings; no controller change.
- Covered by `FindingTest::testTopic*`.
