### PR TITLE
Fix TestCasesController::view() early-return rendering

### DIFF
--- a/src/Controller/TestCasesController.php
+++ b/src/Controller/TestCasesController.php
@@ -71,9 +71,9 @@ class TestCasesController extends TestHelperAppController {
 	/**
 	 * View a specific test case and its methods
 	 *
-	 * @return void
+	 * @return \Cake\Http\Response|null
 	 */
-	public function view(): void {
+	public function view(): ?Response {
 		/** @var string|null $appOrPlugin */
 		$appOrPlugin = $this->request->getQuery('namespace');
 		$plugin = $appOrPlugin !== 'app' ? $appOrPlugin : null;
@@ -82,7 +82,7 @@ class TestCasesController extends TestHelperAppController {
 		if (!$file) {
 			$this->Flash->error('No file specified');
 
-			return;
+			return $this->redirect(['action' => 'browse', '?' => ['namespace' => $appOrPlugin ?: 'app']]);
 		}
 
 		$file = str_replace(['..', "\0"], '', (string)$file); // Security: prevent directory traversal
@@ -93,7 +93,7 @@ class TestCasesController extends TestHelperAppController {
 		if (!file_exists($fullPath)) {
 			$this->Flash->error('Test file not found: ' . $file);
 
-			return;
+			return $this->redirect(['action' => 'browse', '?' => ['namespace' => $appOrPlugin ?: 'app']]);
 		}
 
 		$testPath = ($plugin ? 'plugins' . DS . $plugin . DS . 'tests' : 'tests') . DS . 'TestCase' . DS . $file;
@@ -115,6 +115,8 @@ class TestCasesController extends TestHelperAppController {
 		$className = basename($file, '.php');
 
 		$this->set(compact('methods', 'file', 'testPath', 'breadcrumb', 'namespace', 'plugin', 'className'));
+
+		return null;
 	}
 
 	/**

--- a/tests/TestCase/Controller/TestCasesControllerTest.php
+++ b/tests/TestCase/Controller/TestCasesControllerTest.php
@@ -232,4 +232,52 @@ class TestCasesControllerTest extends TestCase {
 		$this->assertResponseContains('testSuffix');
 	}
 
+	/**
+	 * Viewing without a file query param must redirect to the browse listing
+	 * with an error flash instead of rendering (and failing with a 500).
+	 *
+	 * @return void
+	 */
+	public function testViewWithoutFileRedirects(): void {
+		$this->enableRetainFlashMessages();
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'view',
+			'?' => ['namespace' => 'app'],
+		]);
+
+		$this->assertRedirect([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'browse',
+			'?' => ['namespace' => 'app'],
+		]);
+		$this->assertFlashMessage(__('No file specified'));
+	}
+
+	/**
+	 * Viewing a non-existent file must redirect to the browse listing with an
+	 * error flash instead of rendering (and failing with a 500).
+	 *
+	 * @return void
+	 */
+	public function testViewWithMissingFileRedirects(): void {
+		$this->enableRetainFlashMessages();
+		$this->get([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'view',
+			'?' => ['namespace' => 'app', 'file' => 'DoesNotExistTest.php'],
+		]);
+
+		$this->assertRedirect([
+			'plugin' => 'TestHelper',
+			'controller' => 'TestCases',
+			'action' => 'browse',
+			'?' => ['namespace' => 'app'],
+		]);
+		$this->assertFlashMessage(__('Test file not found: DoesNotExistTest.php'));
+	}
+
 }


### PR DESCRIPTION
## Problem

`TestCasesController::view()` set an error flash and `return`ed early when:

- no `file` query param was given, or
- the resolved file did not exist.

But the early `return` did not stop the response, so the `view` template still
rendered against undefined variables and produced a 500 instead of a graceful
response.

## Fix

Each early-return path now returns a redirect to the `browse` listing
(preserving the `namespace` query value), matching how the controller's other
actions handle the flash-and-redirect pattern. The action signature changes
from void to nullable Response, with an explicit trailing null return so the
happy path keeps rendering the template.

Scope is limited to `view()`.

## Note

There is an open PR that also adds tests to `TestCasesControllerTest.php`. If it
merges first, this branch may need a trivial rebase around the added test
methods.
