### PR TITLE
Support composite foreign keys in the association audit

### DIFF
--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -304,7 +304,9 @@ class AssociationAuditor {
 	public function looseColumnFindings(array $looseColumns, array $codeKeys, array $ignoreColumns, array $aliasByPhysical = [], array $claimedColumns = []): array {
 		$claimed = [];
 		foreach ($codeKeys as $fk) {
-			$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $fk->column] = true;
+			foreach ($fk->columns as $column) {
+				$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $column] = true;
+			}
 		}
 		foreach ($claimedColumns as $id) {
 			$claimed[$id] = true;

--- a/src/Utility/Association/AssociationReader.php
+++ b/src/Utility/Association/AssociationReader.php
@@ -50,15 +50,10 @@ class AssociationReader {
 
 					continue;
 				}
-				if (is_array($foreignKey)) {
-					$unsupported[] = $this->unsupported($table, $association, 'uses a composite foreign key (not auto-verified).');
-
-					continue;
-				}
 
 				$key = $this->normalize($association, $foreignKey);
 				if ($key === null) {
-					$unsupported[] = $this->unsupported($table, $association, 'has a composite binding key (not auto-verified).');
+					$unsupported[] = $this->unsupported($table, $association, 'has composite key columns that do not line up (not auto-verified).');
 
 					continue;
 				}
@@ -147,50 +142,67 @@ class AssociationReader {
 
 	/**
 	 * @param \Cake\ORM\Association $association
-	 * @param string $foreignKey
-	 * @return \TestHelper\Utility\Association\ForeignKey|null Null when the binding key is composite.
+	 * @param array<string>|string $foreignKey
+	 * @return \TestHelper\Utility\Association\ForeignKey|null Null when the columns cannot be paired.
 	 */
-	protected function normalize(Association $association, string $foreignKey): ?ForeignKey {
+	protected function normalize(Association $association, array|string $foreignKey): ?ForeignKey {
 		$source = $association->getSource();
 		$target = $association->getTarget();
 
 		if ($association instanceof BelongsTo) {
 			// FK lives on the source table, references the target's binding key.
 			$ownerTable = $source;
-			$column = $foreignKey;
 			$referenced = $target;
 			$bindingKey = $association->getBindingKey();
 		} elseif ($association instanceof HasMany || $association instanceof HasOne) {
 			// FK lives on the target table, references the source's binding key.
 			$ownerTable = $target;
-			$column = $foreignKey;
 			$referenced = $source;
 			$bindingKey = $association->getBindingKey();
 		} else {
 			return null;
 		}
 
-		if (is_array($bindingKey)) {
+		$columns = array_values((array)$foreignKey);
+		$referencedColumns = $this->referencedColumns($bindingKey, $referenced);
+		// A composite FK whose column counts don't line up can't be paired positionally.
+		if (count($columns) !== count($referencedColumns)) {
 			return null;
 		}
 
-		$referencedColumn = $bindingKey ?: 'id';
 		$ownerColumns = $this->safeColumns($ownerTable);
+		$composite = count($columns) > 1;
 
 		return new ForeignKey(
 			connection: $ownerTable->getConnection()->configName(),
 			ownerTable: $ownerTable->getTable(),
-			column: $column,
+			column: $columns,
 			referencedTable: $referenced->getTable(),
-			referencedColumn: $referencedColumn,
+			referencedColumn: $referencedColumns,
 			source: ForeignKey::SOURCE_CODE,
 			associationType: $this->type($association),
 			declaringTable: $source->getRegistryAlias(),
 			alias: $association->getName(),
-			columnExists: $ownerColumns === null || in_array($column, $ownerColumns, true),
-			ownerColumnType: $this->safeColumnType($ownerTable, $column),
-			referencedColumnType: $this->safeColumnType($referenced, $referencedColumn),
+			columnExists: $ownerColumns === null || !array_diff($columns, $ownerColumns),
+			// Per-column type checks of composite keys are out of scope; only single-column FKs carry types.
+			ownerColumnType: $composite ? null : $this->safeColumnType($ownerTable, $columns[0]),
+			referencedColumnType: $composite ? null : $this->safeColumnType($referenced, $referencedColumns[0]),
 		);
+	}
+
+	/**
+	 * Referenced column(s) for an association: its binding key, falling back to the
+	 * referenced table's primary key, then `id`.
+	 *
+	 * @param array<string>|string|null $bindingKey
+	 * @param \Cake\ORM\Table $referenced
+	 * @return array<string>
+	 */
+	protected function referencedColumns(array|string|null $bindingKey, Table $referenced): array {
+		$value = $bindingKey ?: $referenced->getPrimaryKey();
+		$columns = array_values(array_filter(array_map('strval', (array)$value), fn (string $c): bool => $c !== ''));
+
+		return $columns ?: ['id'];
 	}
 
 	/**

--- a/src/Utility/Association/FixSuggester.php
+++ b/src/Utility/Association/FixSuggester.php
@@ -22,18 +22,22 @@ class FixSuggester {
 
 		// A stray FK on owner -> referenced means the owner is missing a belongsTo,
 		// and the referenced table is missing the reciprocal hasMany.
+		$foreignKey = $this->columnArg($fk->columns);
+		$bindingKey = $this->bindingKeyOption($fk);
 		$belongsTo = sprintf(
-			"// On %sTable::initialize():\n\$this->belongsTo('%s', ['foreignKey' => '%s']);",
+			"// On %sTable::initialize():\n\$this->belongsTo('%s', ['foreignKey' => %s%s]);",
 			$ownerAlias,
 			$alias,
-			$fk->column,
+			$foreignKey,
+			$bindingKey,
 		);
 
 		$hasMany = sprintf(
-			"// Reciprocal, on %sTable::initialize():\n\$this->hasMany('%s', ['foreignKey' => '%s']);",
+			"// Reciprocal, on %sTable::initialize():\n\$this->hasMany('%s', ['foreignKey' => %s%s]);",
 			$alias,
 			$ownerAlias,
-			$fk->column,
+			$foreignKey,
+			$bindingKey,
 		);
 
 		return $belongsTo . "\n" . $hasMany;
@@ -47,12 +51,12 @@ class FixSuggester {
 	 */
 	public function migrationLine(ForeignKey $fk): string {
 		return sprintf(
-			"\$table->addForeignKey('%s', '%s', '%s', [\n"
+			"\$table->addForeignKey(%s, '%s', %s, [\n"
 			. "    'update' => 'NO_ACTION', 'delete' => 'NO_ACTION',\n"
 			. ']);',
-			$fk->column,
+			$this->columnArg($fk->columns),
 			$fk->referencedTable,
-			$fk->referencedColumn,
+			$this->columnArg($fk->referencedColumns),
 		);
 	}
 
@@ -66,22 +70,72 @@ class FixSuggester {
 	 * @return string
 	 */
 	public function columnLine(ForeignKey $fk): string {
+		// Composite: some component columns may already exist, so don't blindly re-add them
+		// all - point at the missing one(s) and let the constraint follow.
+		if ($fk->isComposite()) {
+			return sprintf(
+				"// Some of `%s` (%s) are missing - add the missing component column(s) to match\n"
+				. "// `%s` (%s), then add the constraint:\n"
+				. "\$table->addForeignKey(%s, '%s', %s, [\n"
+				. "    'update' => 'NO_ACTION', 'delete' => 'NO_ACTION',\n"
+				. ']);',
+				$fk->ownerTable,
+				$fk->column,
+				$fk->referencedTable,
+				$fk->referencedColumn,
+				$this->columnArg($fk->columns),
+				$fk->referencedTable,
+				$this->columnArg($fk->referencedColumns),
+			);
+		}
+
 		return sprintf(
 			"// `%s.%s` is missing - add it to match `%s.%s` (copy its type/length), then the constraint:\n"
 			. "\$table->addColumn('%s', '%s', ['null' => true]);\n"
-			. "\$table->addForeignKey('%s', '%s', '%s', [\n"
+			. "\$table->addForeignKey(%s, '%s', %s, [\n"
 			. "    'update' => 'NO_ACTION', 'delete' => 'NO_ACTION',\n"
 			. ']);',
 			$fk->ownerTable,
 			$fk->column,
 			$fk->referencedTable,
 			$fk->referencedColumn,
-			$fk->column,
+			$fk->columns[0],
 			$fk->referencedColumnType ?? 'integer',
-			$fk->column,
+			$this->columnArg($fk->columns),
 			$fk->referencedTable,
-			$fk->referencedColumn,
+			$this->columnArg($fk->referencedColumns),
 		);
+	}
+
+	/**
+	 * A `, 'bindingKey' => ...` association option, but only when the referenced column(s)
+	 * are non-default (composite, or a single column other than `id`). The default `id`
+	 * binding needs no explicit option, keeping the common snippet clean.
+	 *
+	 * @param \TestHelper\Utility\Association\ForeignKey $fk
+	 * @return string
+	 */
+	protected function bindingKeyOption(ForeignKey $fk): string {
+		if ($fk->referencedColumns === ['id']) {
+			return '';
+		}
+
+		return ", 'bindingKey' => " . $this->columnArg($fk->referencedColumns);
+	}
+
+	/**
+	 * Render FK column(s) as a migration/association argument: a quoted name for a single
+	 * column, or a bracketed array for a composite key.
+	 *
+	 * @param array<string> $columns
+	 * @return string
+	 */
+	protected function columnArg(array $columns): string {
+		if (count($columns) === 1) {
+			return "'" . $columns[0] . "'";
+		}
+
+		return "['" . implode("', '", $columns) . "']";
 	}
 
 }

--- a/src/Utility/Association/ForeignKey.php
+++ b/src/Utility/Association/ForeignKey.php
@@ -23,25 +23,53 @@ class ForeignKey {
 	public const SOURCE_CODE = 'code';
 
 	/**
+	 * Owner FK column(s), in order. A composite FK has more than one.
+	 *
+	 * @var array<string>
+	 */
+	public readonly array $columns;
+
+	/**
+	 * Referenced column(s), positionally aligned with $columns.
+	 *
+	 * @var array<string>
+	 */
+	public readonly array $referencedColumns;
+
+	/**
+	 * Display form of the owner column(s): the single name, or comma-joined for composite.
+	 *
+	 * @var string
+	 */
+	public readonly string $column;
+
+	/**
+	 * Display form of the referenced column(s).
+	 *
+	 * @var string
+	 */
+	public readonly string $referencedColumn;
+
+	/**
 	 * @param string $connection Connection name (same table name on another connection is a different target).
 	 * @param string $ownerTable Table that physically holds the FK column.
-	 * @param string $column FK column on the owner table.
+	 * @param array<string>|string $column FK column(s) on the owner table.
 	 * @param string $referencedTable Table the FK points at.
-	 * @param string $referencedColumn Referenced column (usually the PK; honors bindingKey).
+	 * @param array<string>|string $referencedColumn Referenced column(s) (usually the PK; honors bindingKey).
 	 * @param string $source self::SOURCE_DB or self::SOURCE_CODE.
 	 * @param string|null $associationType Association type for code-sourced keys.
 	 * @param string|null $declaringTable Table whose class declared the association (code-sourced).
 	 * @param string|null $alias Association alias (code-sourced).
-	 * @param bool $columnExists Whether the owner column physically exists (code-sourced).
-	 * @param string|null $ownerColumnType Abstract DB type of the owner column (code-sourced), or null if unresolved.
-	 * @param string|null $referencedColumnType Abstract DB type of the referenced column (code-sourced), or null if unresolved.
+	 * @param bool $columnExists Whether the owner column(s) physically exist (code-sourced).
+	 * @param string|null $ownerColumnType Abstract DB type of the owner column (code-sourced, single-column only), or null.
+	 * @param string|null $referencedColumnType Abstract DB type of the referenced column (code-sourced, single-column only), or null.
 	 */
 	public function __construct(
 		public readonly string $connection,
 		public readonly string $ownerTable,
-		public readonly string $column,
+		array|string $column,
 		public readonly string $referencedTable,
-		public readonly string $referencedColumn,
+		array|string $referencedColumn,
 		public readonly string $source,
 		public readonly ?string $associationType = null,
 		public readonly ?string $declaringTable = null,
@@ -50,6 +78,19 @@ class ForeignKey {
 		public readonly ?string $ownerColumnType = null,
 		public readonly ?string $referencedColumnType = null,
 	) {
+		$this->columns = is_array($column) ? array_values($column) : [$column];
+		$this->referencedColumns = is_array($referencedColumn) ? array_values($referencedColumn) : [$referencedColumn];
+		$this->column = implode(', ', $this->columns);
+		$this->referencedColumn = implode(', ', $this->referencedColumns);
+	}
+
+	/**
+	 * Whether this FK spans more than one column.
+	 *
+	 * @return bool
+	 */
+	public function isComposite(): bool {
+		return count($this->columns) > 1;
 	}
 
 	/**

--- a/src/Utility/Association/JoinTableResolver.php
+++ b/src/Utility/Association/JoinTableResolver.php
@@ -36,31 +36,18 @@ class JoinTableResolver {
 			return [[], [$finding]];
 		}
 
-		$sourceForeignKey = $association->getForeignKey();
-		$targetForeignKey = $association->getTargetForeignKey();
-		if (!is_string($sourceForeignKey) || !is_string($targetForeignKey)) {
-			$finding = new Finding(
-				table: $source->getRegistryAlias(),
-				direction: Finding::DIRECTION_UNSUPPORTED,
-				associationType: 'belongsToMany',
-				severity: Finding::SEVERITY_INFO,
-				message: sprintf('belongsToMany `%s`: composite junction keys are not auto-verified.', $association->getName()),
-				target: $target->getAlias(),
-			);
-
-			return [[], [$finding]];
-		}
-
 		// Resolve referenced columns from the actual binding keys (honoring custom bindingKey).
-		$sourceBindingKey = $this->bindingColumn($association->getBindingKey(), $source->getPrimaryKey());
-		$targetBindingKey = $this->bindingColumn($this->targetBindingKey($junction, $target->getAlias()), $target->getPrimaryKey());
-		if ($sourceBindingKey === null || $targetBindingKey === null) {
+		$sourceColumns = $this->columnList($association->getForeignKey());
+		$targetColumns = $this->columnList($association->getTargetForeignKey());
+		$sourceBindingColumns = $this->bindingColumns($association->getBindingKey(), $source->getPrimaryKey());
+		$targetBindingColumns = $this->bindingColumns($this->targetBindingKey($junction, $target->getAlias()), $target->getPrimaryKey());
+		if (count($sourceColumns) !== count($sourceBindingColumns) || count($targetColumns) !== count($targetBindingColumns)) {
 			$finding = new Finding(
 				table: $source->getRegistryAlias(),
 				direction: Finding::DIRECTION_UNSUPPORTED,
 				associationType: 'belongsToMany',
 				severity: Finding::SEVERITY_INFO,
-				message: sprintf('belongsToMany `%s`: composite binding key is not auto-verified.', $association->getName()),
+				message: sprintf('belongsToMany `%s`: composite junction keys do not line up (not auto-verified).', $association->getName()),
 				target: $target->getAlias(),
 			);
 
@@ -71,35 +58,37 @@ class JoinTableResolver {
 		$junctionTable = $junction->getTable();
 		$declaringTable = $source->getRegistryAlias();
 		$junctionColumns = $this->safeColumns($junction);
+		$sourceComposite = count($sourceColumns) > 1;
+		$targetComposite = count($targetColumns) > 1;
 
 		$keys = [
 			new ForeignKey(
 				connection: $junctionConnection,
 				ownerTable: $junctionTable,
-				column: $sourceForeignKey,
+				column: $sourceColumns,
 				referencedTable: $source->getTable(),
-				referencedColumn: $sourceBindingKey,
+				referencedColumn: $sourceBindingColumns,
 				source: ForeignKey::SOURCE_CODE,
 				associationType: 'belongsToMany',
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
-				columnExists: $junctionColumns === null || in_array($sourceForeignKey, $junctionColumns, true),
-				ownerColumnType: $this->safeColumnType($junction, $sourceForeignKey),
-				referencedColumnType: $this->safeColumnType($source, $sourceBindingKey),
+				columnExists: $junctionColumns === null || !array_diff($sourceColumns, $junctionColumns),
+				ownerColumnType: $sourceComposite ? null : $this->safeColumnType($junction, $sourceColumns[0]),
+				referencedColumnType: $sourceComposite ? null : $this->safeColumnType($source, $sourceBindingColumns[0]),
 			),
 			new ForeignKey(
 				connection: $junctionConnection,
 				ownerTable: $junctionTable,
-				column: $targetForeignKey,
+				column: $targetColumns,
 				referencedTable: $target->getTable(),
-				referencedColumn: $targetBindingKey,
+				referencedColumn: $targetBindingColumns,
 				source: ForeignKey::SOURCE_CODE,
 				associationType: 'belongsToMany',
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
-				columnExists: $junctionColumns === null || in_array($targetForeignKey, $junctionColumns, true),
-				ownerColumnType: $this->safeColumnType($junction, $targetForeignKey),
-				referencedColumnType: $this->safeColumnType($target, $targetBindingKey),
+				columnExists: $junctionColumns === null || !array_diff($targetColumns, $junctionColumns),
+				ownerColumnType: $targetComposite ? null : $this->safeColumnType($junction, $targetColumns[0]),
+				referencedColumnType: $targetComposite ? null : $this->safeColumnType($target, $targetBindingColumns[0]),
 			),
 		];
 
@@ -126,20 +115,31 @@ class JoinTableResolver {
 	}
 
 	/**
-	 * Resolve a single binding column. Composite (multi-column) binding keys return
-	 * null so the caller can flag the association as unsupported rather than guessing.
+	 * Normalize a junction foreign key (array/string, possibly empty) into a column list.
+	 *
+	 * @param array<int|string, string|false>|string|false $foreignKey
+	 * @return array<string>
+	 */
+	protected function columnList(array|string|false $foreignKey): array {
+		if ($foreignKey === false) {
+			return [];
+		}
+
+		return array_values(array_filter(array_map('strval', (array)$foreignKey), fn (string $c): bool => $c !== ''));
+	}
+
+	/**
+	 * Resolve the binding column(s) for one side of the junction: the explicit binding key,
+	 * falling back to the table's primary key.
 	 *
 	 * @param array<string>|string|null $bindingKey
 	 * @param array<string>|string $primaryKey
-	 * @return string|null
+	 * @return array<string>
 	 */
-	protected function bindingColumn(array|string|null $bindingKey, array|string $primaryKey): ?string {
+	protected function bindingColumns(array|string|null $bindingKey, array|string $primaryKey): array {
 		$value = $bindingKey ?: $primaryKey;
-		if (is_array($value)) {
-			return count($value) === 1 ? (string)reset($value) : null;
-		}
 
-		return $value;
+		return array_values(array_filter(array_map('strval', (array)$value), fn (string $c): bool => $c !== ''));
 	}
 
 }

--- a/src/Utility/Association/SchemaIntrospector.php
+++ b/src/Utility/Association/SchemaIntrospector.php
@@ -28,21 +28,20 @@ class SchemaIntrospector {
 				continue;
 			}
 
-			$columns = (array)($constraint['columns'] ?? []);
+			$columns = array_map('strval', (array)($constraint['columns'] ?? []));
 			$references = $constraint['references'] ?? null;
-			if (count($columns) !== 1 || !is_array($references)) {
-				// Composite FKs are not deep-validated in v1.
+			if (!$columns || !is_array($references)) {
 				continue;
 			}
 
-			[$referencedTable, $referencedColumn] = $this->normalizeReferences($references);
+			[$referencedTable, $referencedColumns] = $this->normalizeReferences($references);
 
 			$keys[] = new ForeignKey(
 				connection: $connectionName,
 				ownerTable: $table,
-				column: (string)$columns[0],
+				column: $columns,
 				referencedTable: $referencedTable,
-				referencedColumn: $referencedColumn,
+				referencedColumn: $referencedColumns,
 				source: ForeignKey::SOURCE_DB,
 			);
 		}
@@ -93,16 +92,18 @@ class SchemaIntrospector {
 
 	/**
 	 * @param array<int|string, mixed> $references
-	 * @return array{0: string, 1: string}
+	 * @return array{0: string, 1: array<string>}
 	 */
 	protected function normalizeReferences(array $references): array {
 		$referencedTable = (string)($references[0] ?? '');
-		$referencedColumn = $references[1] ?? 'id';
-		if (is_array($referencedColumn)) {
-			$referencedColumn = (string)(reset($referencedColumn) ?: 'id');
+		$referencedColumns = $references[1] ?? 'id';
+		$referencedColumns = is_array($referencedColumns) ? array_values($referencedColumns) : [$referencedColumns];
+		$referencedColumns = array_map('strval', $referencedColumns);
+		if (!$referencedColumns) {
+			$referencedColumns = ['id'];
 		}
 
-		return [$referencedTable, (string)$referencedColumn];
+		return [$referencedTable, $referencedColumns];
 	}
 
 }

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -110,6 +110,43 @@ class AssociationAuditorTest extends TestCase {
 	}
 
 	/**
+	 * A composite code FK matching a composite DB FK produces no finding (paired by the
+	 * ordered column identity).
+	 *
+	 * @return void
+	 */
+	public function testDiffCompositeAligned() {
+		$code = [
+			new ForeignKey('default', 'memberships', ['region', 'parent_code'], 'cparents', ['region', 'code'], ForeignKey::SOURCE_CODE, 'belongsTo', 'Memberships', 'Cparents', true),
+		];
+		$db = [
+			new ForeignKey('default', 'memberships', ['region', 'parent_code'], 'cparents', ['region', 'code'], ForeignKey::SOURCE_DB),
+		];
+
+		$findings = $this->auditor->diffForeignKeys($code, $db);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * A composite code FK with no DB constraint is db_missing, and its fix renders the
+	 * columns as arrays (not a comma-joined string).
+	 *
+	 * @return void
+	 */
+	public function testDiffCompositeDbMissing() {
+		$code = [
+			new ForeignKey('default', 'memberships', ['region', 'parent_code'], 'cparents', ['region', 'code'], ForeignKey::SOURCE_CODE, 'belongsTo', 'Memberships', 'Cparents', true),
+		];
+
+		$findings = $this->auditor->diffForeignKeys($code, []);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_DB_MISSING, $findings[0]->direction);
+		$this->assertStringContainsString("['region', 'parent_code']", (string)$findings[0]->fixSnippet);
+	}
+
+	/**
 	 * Matching code and DB keys produce no findings (and the reciprocal dedupes).
 	 *
 	 * @return void

--- a/tests/TestCase/Utility/Association/AssociationReaderTest.php
+++ b/tests/TestCase/Utility/Association/AssociationReaderTest.php
@@ -211,7 +211,7 @@ class AssociationReaderTest extends TestCase {
 		$this->assertSame([], $keys);
 		$this->assertCount(1, $unsupported);
 		$this->assertSame('unsupported', $unsupported[0]->direction);
-		$this->assertStringContainsString('composite binding key', $unsupported[0]->message);
+		$this->assertStringContainsString('do not line up', $unsupported[0]->message);
 	}
 
 	/**
@@ -229,6 +229,32 @@ class AssociationReaderTest extends TestCase {
 		$this->assertSame([], $keys);
 		$this->assertCount(1, $unsupported);
 		$this->assertSame('unsupported', $unsupported[0]->direction);
+	}
+
+	/**
+	 * A composite foreign key is read as ordered column arrays paired with the binding key.
+	 *
+	 * @return void
+	 */
+	public function testBelongsToCompositeForeignKey() {
+		$this->table('Tenants', 'tenants', [
+			'tenant_id' => ['type' => 'integer'],
+			'code' => ['type' => 'integer'],
+			'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['tenant_id', 'code']]],
+		]);
+		$users = $this->table('Users', 'users', [
+			'id' => ['type' => 'integer'],
+			'tenant_id' => ['type' => 'integer'],
+			'tenant_code' => ['type' => 'integer'],
+		]);
+		$users->belongsTo('Tenants', ['foreignKey' => ['tenant_id', 'tenant_code'], 'bindingKey' => ['tenant_id', 'code']]);
+
+		[$keys] = $this->reader->read($users);
+
+		$this->assertCount(1, $keys);
+		$this->assertTrue($keys[0]->isComposite());
+		$this->assertSame(['tenant_id', 'tenant_code'], $keys[0]->columns);
+		$this->assertSame(['tenant_id', 'code'], $keys[0]->referencedColumns);
 	}
 
 }

--- a/tests/TestCase/Utility/Association/ForeignKeyTest.php
+++ b/tests/TestCase/Utility/Association/ForeignKeyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Utility\Association;
+
+use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\ForeignKey;
+
+class ForeignKeyTest extends TestCase {
+
+	/**
+	 * A composite FK exposes its columns as ordered arrays plus a joined display form.
+	 *
+	 * @return void
+	 */
+	public function testCompositeColumnsExposedAsArrays() {
+		$fk = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_DB);
+
+		$this->assertSame(['tenant_id', 'user_id'], $fk->columns);
+		$this->assertSame(['tenant_id', 'id'], $fk->referencedColumns);
+		$this->assertSame('tenant_id, user_id', $fk->column);
+		$this->assertSame('tenant_id, id', $fk->referencedColumn);
+		$this->assertTrue($fk->isComposite());
+	}
+
+	/**
+	 * A single-column FK keeps the string accessors and is not composite (backward compat).
+	 *
+	 * @return void
+	 */
+	public function testSingleColumnBackwardCompatible() {
+		$fk = new ForeignKey('default', 'posts', 'author_id', 'authors', 'id', ForeignKey::SOURCE_DB);
+
+		$this->assertSame(['author_id'], $fk->columns);
+		$this->assertSame('author_id', $fk->column);
+		$this->assertSame('id', $fk->referencedColumn);
+		$this->assertFalse($fk->isComposite());
+	}
+
+	/**
+	 * The identity key folds the ordered columns in, so composite keys compare correctly.
+	 *
+	 * @return void
+	 */
+	public function testCompositeKeyIdentity() {
+		$a = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_CODE);
+		$b = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_DB);
+
+		$this->assertSame($a->key(), $b->key());
+	}
+
+}

--- a/tests/TestCase/Utility/Association/SchemaIntrospectorTest.php
+++ b/tests/TestCase/Utility/Association/SchemaIntrospectorTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Utility\Association;
+
+use Cake\Database\Connection;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\SchemaIntrospector;
+use Throwable;
+
+class SchemaIntrospectorTest extends TestCase {
+
+	protected Connection $connection;
+
+	protected SchemaIntrospector $introspector;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$connection = ConnectionManager::get('test');
+		if (!$connection instanceof Connection) {
+			$this->markTestSkipped('Test connection is not a database connection.');
+		}
+		$this->connection = $connection;
+		$this->introspector = new SchemaIntrospector();
+
+		$this->dropTables();
+		$this->createTables();
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$this->dropTables();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A single-column foreign key is introspected with its owner and referenced column.
+	 *
+	 * @return void
+	 */
+	public function testForeignKeysCaptureSingleColumn() {
+		$keys = $this->introspector->foreignKeys($this->connection, 'th_audit_children');
+
+		$this->assertCount(1, $keys);
+		$key = $keys[0];
+		$this->assertSame('parent_id', $key->column);
+		$this->assertSame('th_audit_parents', $key->referencedTable);
+		$this->assertSame('id', $key->referencedColumn);
+		$this->assertFalse($key->isComposite());
+	}
+
+	/**
+	 * A composite foreign key is introspected as ordered column arrays, not skipped.
+	 *
+	 * @return void
+	 */
+	public function testForeignKeysCaptureCompositeColumns() {
+		$this->createCompositeTables();
+
+		$keys = $this->introspector->foreignKeys($this->connection, 'th_audit_memberships');
+
+		$this->assertCount(1, $keys);
+		$this->assertSame(['region', 'parent_code'], $keys[0]->columns);
+		$this->assertSame('th_audit_cparents', $keys[0]->referencedTable);
+		$this->assertSame(['region', 'code'], $keys[0]->referencedColumns);
+		$this->assertTrue($keys[0]->isComposite());
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function createTables(): void {
+		$parents = (new TableSchema('th_audit_parents'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+
+		$children = (new TableSchema('th_audit_children'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addColumn('parent_id', ['type' => 'integer', 'null' => true])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']])
+			->addConstraint('fk_audit_parent', [
+				'type' => 'foreign',
+				'columns' => ['parent_id'],
+				'references' => ['th_audit_parents', 'id'],
+				'delete' => TableSchema::ACTION_NO_ACTION,
+				'update' => TableSchema::ACTION_NO_ACTION,
+			]);
+
+		foreach ($parents->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+		foreach ($children->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function createCompositeTables(): void {
+		$parents = (new TableSchema('th_audit_cparents'))
+			->addColumn('region', ['type' => 'integer', 'null' => false])
+			->addColumn('code', ['type' => 'integer', 'null' => false])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['region', 'code']]);
+
+		$memberships = (new TableSchema('th_audit_memberships'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addColumn('region', ['type' => 'integer', 'null' => true])
+			->addColumn('parent_code', ['type' => 'integer', 'null' => true])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']])
+			->addConstraint('fk_audit_membership', [
+				'type' => 'foreign',
+				'columns' => ['region', 'parent_code'],
+				'references' => ['th_audit_cparents', ['region', 'code']],
+				'delete' => TableSchema::ACTION_NO_ACTION,
+				'update' => TableSchema::ACTION_NO_ACTION,
+			]);
+
+		foreach ($parents->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+		foreach ($memberships->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function dropTables(): void {
+		foreach (['th_audit_children', 'th_audit_memberships', 'th_audit_parents', 'th_audit_cparents'] as $table) {
+			$schema = new TableSchema($table);
+			foreach ($schema->dropSql($this->connection) as $sql) {
+				try {
+					$this->connection->execute($sql);
+				} catch (Throwable $e) {
+					// Table may not exist yet; ignore.
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
First step of porting the held `_association-features.patch` onto current master: **composite (multi-column) foreign-key support**. The cascade-rule layer and the new `docs/Associations.md` follow in a subsequent PR.

## What

Composite foreign keys were previously reported as "unsupported" and skipped. They're now audited like single-column keys.

- **`ForeignKey`** carries ordered `columns[]` / `referencedColumns[]` arrays alongside the existing string `column` / `referencedColumn` (comma-joined for composite), plus `isComposite()`. The constructor accepts `array|string`, so every existing single-column caller is unchanged.
- **`AssociationReader`** / **`JoinTableResolver`** pair composite owner and binding columns positionally instead of bailing; a genuine count mismatch is still reported unsupported, with a clearer message.
- **`SchemaIntrospector`** reads composite DB foreign keys (it was single-column-only).
- **`FixSuggester`** renders columns as arrays (`['a', 'b']`) for composite keys and adds a `bindingKey` option when the referenced columns are non-default; the missing-column snippet no longer blindly re-adds existing component columns.
- The loose-column layer claims **each** component column of a composite key.

## Scope / safety

- Single-column behavior (type checks, narrowing, column-missing, sort, loose columns) is unchanged — verified by the existing suite.
- New `ForeignKeyTest` and `SchemaIntrospectorTest`, plus composite cases in the reader/auditor tests.
- Deferred to the follow-up: the cascade-rule (ON DELETE / `dependent`) layer and its `ForeignKey` `dependent`/`onUpdate`/`onDelete` fields.
