### PR TITLE
Association audit: cascade-rule layer, composite FKs, type fix, matrix columns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,12 +77,15 @@ Audits whether your declared table associations (`belongsTo`, `hasMany`, `hasOne
 * an association declared in code whose column exists but has no matching DB foreign-key constraint (warning; suggests an `addForeignKey()` migration line)
 * a DB foreign key with no matching association (suggests the `belongsTo`/`hasMany` call)
 * a target/column disagreement between the two
-* a key-type layer compares each declared foreign key's column type against the referenced key: a different type family (e.g. `integer` referencing `uuid`) is an error, an owner key narrower than the referenced key (e.g. `integer` referencing `biginteger`) is a warning, and matching non-integer keys are an info hint that integer keys are preferred (silence the hint with `TestHelper.associationAudit.preferIntegerKeys => false`)
+* a key-type layer compares each declared foreign key's column type against the referenced key: a different type family (e.g. `integer` referencing `uuid`) is an error (suggests a `changeColumn()` migration line aligning the column to its target), an owner key narrower than the referenced key (e.g. `integer` referencing `biginteger`) is a warning (same `changeColumn()` fix), and matching non-integer keys are an info hint that integer keys are preferred (silence the hint with `TestHelper.associationAudit.preferIntegerKeys => false`)
+* a cascade-rule layer compares the ORM `dependent` intent of a `hasMany`/`hasOne` against the matching DB foreign key's `ON DELETE` rule (info): a `dependent` association whose DB FK uses `ON DELETE NO ACTION` won't cascade a delete issued directly in SQL (suggests switching the FK to `ON DELETE CASCADE`, preserving the existing `ON UPDATE` rule), and a DB `ON DELETE CASCADE` with a non-`dependent` association means the ORM won't fire child callbacks (suggests adding `'dependent' => true, 'cascadeCallbacks' => true`)
 * a secondary layer flags `*_id` columns that have neither a constraint nor an association (configurable ignore list via `TestHelper.associationAudit.ignoreColumns` for polymorphic columns)
+
+Composite (multi-column) foreign keys are fully diffed in the constraint layer for `belongsTo`/`hasMany`/`hasOne` and for `belongsToMany` junctions; fix snippets render the columns as arrays and pin a non-default `bindingKey`. Composite keys are diffed structurally but not type-checked.
 
 App and first-party plugin tables are scanned by default; vendor tables can be folded in via the toggle.
 
-The summary matrix shows every table against each association type, colour-coded by status:
+The summary matrix shows every table against each association type plus the two cross-cutting layers (`Key type` and `Cascade`) as their own columns, color-coded by status:
 
 ![Association audit matrix](img/associations_matrix.png)
 

--- a/src/Controller/AssociationsController.php
+++ b/src/Controller/AssociationsController.php
@@ -14,11 +14,12 @@ class AssociationsController extends TestHelperAppController {
 	protected ?string $defaultTable = '';
 
 	/**
-	 * Association types shown as matrix columns.
+	 * Matrix columns: the association types, then the two cross-cutting audit layers
+	 * (key-type and cascade-rule) as their own dimensions.
 	 *
 	 * @var array<string>
 	 */
-	protected array $columns = ['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'looseColumn'];
+	protected array $columns = ['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'looseColumn', 'keyType', 'cascadeRule'];
 
 	/**
 	 * Summary matrix across all in-scope tables.
@@ -118,7 +119,7 @@ class AssociationsController extends TestHelperAppController {
 			if (!isset($matrix[$finding->table])) {
 				continue;
 			}
-			$column = in_array($finding->associationType, $this->columns, true) ? $finding->associationType : 'belongsTo';
+			$column = $this->columnFor($finding);
 
 			$cell = $matrix[$finding->table][$column];
 			$cell['count']++;
@@ -130,6 +131,21 @@ class AssociationsController extends TestHelperAppController {
 	}
 
 	/**
+	 * Matrix column a finding belongs in: the cross-cutting layers get their own column,
+	 * everything else stays under its association type.
+	 *
+	 * @param \TestHelper\Utility\Association\Finding $finding
+	 * @return string
+	 */
+	protected function columnFor(Finding $finding): string {
+		return match ($finding->layer) {
+			Finding::LAYER_TYPE => 'keyType',
+			Finding::LAYER_RULE => 'cascadeRule',
+			default => in_array($finding->associationType, $this->columns, true) ? $finding->associationType : 'belongsTo',
+		};
+	}
+
+	/**
 	 * @param array<\TestHelper\Utility\Association\Finding> $findings
 	 * @return array<string, array<\TestHelper\Utility\Association\Finding>>
 	 */
@@ -138,6 +154,7 @@ class AssociationsController extends TestHelperAppController {
 			Finding::DIRECTION_MISMATCH => [],
 			Finding::DIRECTION_COLUMN_MISSING => [],
 			Finding::DIRECTION_TYPE => [],
+			Finding::DIRECTION_RULE => [],
 			Finding::DIRECTION_DB_MISSING => [],
 			Finding::DIRECTION_CODE_MISSING => [],
 			Finding::DIRECTION_UNSUPPORTED => [],

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -4,6 +4,7 @@ namespace TestHelper\Utility\Association;
 
 use Cake\Core\Configure;
 use Cake\Database\Connection;
+use Cake\Database\Schema\TableSchema;
 use Cake\Datasource\ConnectionManager;
 use Cake\ORM\Locator\LocatorAwareTrait;
 use Throwable;
@@ -134,7 +135,8 @@ class AssociationAuditor {
 
 		$findings = array_merge($findings, $this->diffForeignKeys($codeKeys, $dbKeys, $aliasByPhysical));
 		$findings = array_merge($findings, $this->looseColumnFindings($looseColumns, $codeKeys, $this->ignoreColumns(), $aliasByPhysical, $claimedColumns));
-		$findings = array_merge($findings, $this->typeFindings($codeKeys));
+		$findings = array_merge($findings, $this->typeFindings($codeKeys, $this->preferIntegerKeys()));
+		$findings = array_merge($findings, $this->ruleFindings($codeKeys, $dbKeys));
 
 		return $findings;
 	}
@@ -304,7 +306,9 @@ class AssociationAuditor {
 	public function looseColumnFindings(array $looseColumns, array $codeKeys, array $ignoreColumns, array $aliasByPhysical = [], array $claimedColumns = []): array {
 		$claimed = [];
 		foreach ($codeKeys as $fk) {
-			$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $fk->column] = true;
+			foreach ($fk->columns as $column) {
+				$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $column] = true;
+			}
 		}
 		foreach ($claimedColumns as $id) {
 			$claimed[$id] = true;
@@ -349,9 +353,12 @@ class AssociationAuditor {
 	 *   ideal - silenced via `TestHelper.associationAudit.preferIntegerKeys`.
 	 *
 	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
+	 * @param bool|null $preferIntegerKeys When false, the non-integer info advisory is suppressed
+	 *   (errors remain); null falls back to the `TestHelper.associationAudit.preferIntegerKeys` config.
 	 * @return array<\TestHelper\Utility\Association\Finding>
 	 */
-	public function typeFindings(array $codeKeys): array {
+	public function typeFindings(array $codeKeys, ?bool $preferIntegerKeys = null): array {
+		$preferIntegerKeys ??= $this->preferIntegerKeys();
 		$seen = [];
 		$findings = [];
 
@@ -385,6 +392,7 @@ class AssociationAuditor {
 					),
 					column: $fk->column,
 					target: $fk->referencedTable,
+					fixSnippet: $this->fixSuggester->typeAlignmentLine($fk),
 					layer: Finding::LAYER_TYPE,
 				);
 
@@ -415,6 +423,8 @@ class AssociationAuditor {
 					),
 					column: $fk->column,
 					target: $fk->referencedTable,
+					// A narrower integer FK is widened to its referenced key by the same changeColumn fix.
+					fixSnippet: $this->fixSuggester->typeAlignmentLine($fk),
 					layer: Finding::LAYER_TYPE,
 				);
 
@@ -423,7 +433,7 @@ class AssociationAuditor {
 
 			// Matching non-integer keys: integer keys are the ideal, so note it as info
 			// unless the app deliberately standardizes on another key type.
-			if (!$this->preferIntegerKeys()) {
+			if (!$preferIntegerKeys) {
 				continue;
 			}
 
@@ -447,6 +457,102 @@ class AssociationAuditor {
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Pure cascade-rule layer: compares each dependent association's ORM intent against the
+	 * matched DB FK's `ON DELETE` rule. Divergence is reported as info, not an error, because
+	 * relying on ORM-level cascades with a `NO ACTION` DB rule is a deliberate, common CakePHP
+	 * setup. Only hasMany/hasOne carry a dependent intent; belongsTo and DB-only keys are
+	 * skipped. `ON UPDATE` has no ORM equivalent and is not compared.
+	 *
+	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
+	 * @param array<\TestHelper\Utility\Association\ForeignKey> $dbKeys
+	 * @return array<\TestHelper\Utility\Association\Finding>
+	 */
+	public function ruleFindings(array $codeKeys, array $dbKeys): array {
+		$dbByKey = [];
+		foreach ($dbKeys as $fk) {
+			$dbByKey[$fk->key()] = $fk;
+		}
+
+		$findings = [];
+		foreach ($codeKeys as $fk) {
+			// Each association is checked on its own: aliases sharing one physical FK can carry
+			// different `dependent` settings, so deduping by key() here would drop real findings.
+			// Reciprocal belongsTo declarations carry a null intent and fall through below.
+			if ($fk->dependent === null) {
+				continue;
+			}
+
+			$dbFk = $dbByKey[$fk->key()] ?? null;
+			if ($dbFk === null || $dbFk->onDelete === null) {
+				// No comparable DB FK: the constraint layer already reports the missing FK.
+				continue;
+			}
+
+			$cascades = $dbFk->onDelete === TableSchema::ACTION_CASCADE;
+
+			if ($fk->dependent && !$cascades) {
+				$findings[] = new Finding(
+					table: $fk->declaringTable ?? $fk->ownerTable,
+					direction: Finding::DIRECTION_RULE,
+					associationType: $fk->associationType ?? 'hasMany',
+					severity: Finding::SEVERITY_INFO,
+					message: sprintf(
+						'Association `%s` is `dependent` (app-level cascade delete) but the DB FK `%s.%s` uses ON DELETE %s; a delete issued directly in SQL will not cascade.',
+						$fk->alias ?? $fk->referencedTable,
+						$fk->ownerTable,
+						$fk->column,
+						$this->ruleLabel($dbFk->onDelete),
+					),
+					column: $fk->column,
+					target: $fk->referencedTable,
+					fixSnippet: $this->fixSuggester->cascadeMigrationLine($fk, $dbFk->onUpdate),
+					layer: Finding::LAYER_RULE,
+				);
+
+				continue;
+			}
+
+			if (!$fk->dependent && $cascades) {
+				$findings[] = new Finding(
+					table: $fk->declaringTable ?? $fk->ownerTable,
+					direction: Finding::DIRECTION_RULE,
+					associationType: $fk->associationType ?? 'hasMany',
+					severity: Finding::SEVERITY_INFO,
+					message: sprintf(
+						'DB FK `%s.%s` uses ON DELETE CASCADE but association `%s` is not `dependent`; rows the DB removes will not trigger ORM callbacks.',
+						$fk->ownerTable,
+						$fk->column,
+						$fk->alias ?? $fk->referencedTable,
+					),
+					column: $fk->column,
+					target: $fk->referencedTable,
+					fixSnippet: $this->fixSuggester->dependentOption($fk),
+					layer: Finding::LAYER_RULE,
+				);
+			}
+		}
+
+		return $findings;
+	}
+
+	/**
+	 * Human-readable SQL label for an internal cascade-action string.
+	 *
+	 * @param string $action One of the TableSchema::ACTION_* values.
+	 * @return string
+	 */
+	protected function ruleLabel(string $action): string {
+		return match ($action) {
+			TableSchema::ACTION_CASCADE => 'CASCADE',
+			TableSchema::ACTION_SET_NULL => 'SET NULL',
+			TableSchema::ACTION_NO_ACTION => 'NO ACTION',
+			TableSchema::ACTION_RESTRICT => 'RESTRICT',
+			TableSchema::ACTION_SET_DEFAULT => 'SET DEFAULT',
+			default => strtoupper($action),
+		};
 	}
 
 	/**

--- a/src/Utility/Association/AssociationReader.php
+++ b/src/Utility/Association/AssociationReader.php
@@ -50,15 +50,10 @@ class AssociationReader {
 
 					continue;
 				}
-				if (is_array($foreignKey)) {
-					$unsupported[] = $this->unsupported($table, $association, 'uses a composite foreign key (not auto-verified).');
-
-					continue;
-				}
 
 				$key = $this->normalize($association, $foreignKey);
 				if ($key === null) {
-					$unsupported[] = $this->unsupported($table, $association, 'has a composite binding key (not auto-verified).');
+					$unsupported[] = $this->unsupported($table, $association, 'has composite key columns that do not line up (not auto-verified).');
 
 					continue;
 				}
@@ -147,50 +142,72 @@ class AssociationReader {
 
 	/**
 	 * @param \Cake\ORM\Association $association
-	 * @param string $foreignKey
-	 * @return \TestHelper\Utility\Association\ForeignKey|null Null when the binding key is composite.
+	 * @param array<string>|string $foreignKey
+	 * @return \TestHelper\Utility\Association\ForeignKey|null Null when the columns cannot be paired.
 	 */
-	protected function normalize(Association $association, string $foreignKey): ?ForeignKey {
+	protected function normalize(Association $association, array|string $foreignKey): ?ForeignKey {
 		$source = $association->getSource();
 		$target = $association->getTarget();
 
+		// `dependent` (ORM cascade-delete intent) only applies to the owning side; belongsTo
+		// has no such concept, so it stays null and is skipped by the rule layer.
+		$dependent = null;
 		if ($association instanceof BelongsTo) {
 			// FK lives on the source table, references the target's binding key.
 			$ownerTable = $source;
-			$column = $foreignKey;
 			$referenced = $target;
 			$bindingKey = $association->getBindingKey();
 		} elseif ($association instanceof HasMany || $association instanceof HasOne) {
 			// FK lives on the target table, references the source's binding key.
 			$ownerTable = $target;
-			$column = $foreignKey;
 			$referenced = $source;
 			$bindingKey = $association->getBindingKey();
+			$dependent = $association->getDependent();
 		} else {
 			return null;
 		}
 
-		if (is_array($bindingKey)) {
+		$columns = array_values((array)$foreignKey);
+		$referencedColumns = $this->referencedColumns($bindingKey, $referenced);
+		// A composite FK whose column counts don't line up can't be paired positionally.
+		if (count($columns) !== count($referencedColumns)) {
 			return null;
 		}
 
-		$referencedColumn = $bindingKey ?: 'id';
 		$ownerColumns = $this->safeColumns($ownerTable);
+		$composite = count($columns) > 1;
 
 		return new ForeignKey(
 			connection: $ownerTable->getConnection()->configName(),
 			ownerTable: $ownerTable->getTable(),
-			column: $column,
+			column: $columns,
 			referencedTable: $referenced->getTable(),
-			referencedColumn: $referencedColumn,
+			referencedColumn: $referencedColumns,
 			source: ForeignKey::SOURCE_CODE,
 			associationType: $this->type($association),
 			declaringTable: $source->getRegistryAlias(),
 			alias: $association->getName(),
-			columnExists: $ownerColumns === null || in_array($column, $ownerColumns, true),
-			ownerColumnType: $this->safeColumnType($ownerTable, $column),
-			referencedColumnType: $this->safeColumnType($referenced, $referencedColumn),
+			columnExists: $ownerColumns === null || !array_diff($columns, $ownerColumns),
+			// Per-column type-checking of composite keys is a separate concern; only single-column FKs carry types.
+			ownerColumnType: $composite ? null : $this->safeColumnType($ownerTable, $columns[0]),
+			referencedColumnType: $composite ? null : $this->safeColumnType($referenced, $referencedColumns[0]),
+			dependent: $dependent,
 		);
+	}
+
+	/**
+	 * Referenced column(s) for an association: its binding key, falling back to the referenced
+	 * table's primary key, then `id`.
+	 *
+	 * @param array<string>|string|null $bindingKey
+	 * @param \Cake\ORM\Table $referenced
+	 * @return array<string>
+	 */
+	protected function referencedColumns(array|string|null $bindingKey, Table $referenced): array {
+		$value = $bindingKey ?: $referenced->getPrimaryKey();
+		$columns = array_values(array_filter(array_map('strval', (array)$value), fn (string $c): bool => $c !== ''));
+
+		return $columns ?: ['id'];
 	}
 
 	/**

--- a/src/Utility/Association/Finding.php
+++ b/src/Utility/Association/Finding.php
@@ -45,6 +45,12 @@ class Finding {
 	public const DIRECTION_TYPE = 'type';
 
 	/**
+	 * Cascade-rule observation: the ORM `dependent` intent and the DB FK rule disagree.
+     * @var string
+	 */
+	public const DIRECTION_RULE = 'rule';
+
+	/**
      * @var string
      */
 	public const SEVERITY_ERROR = 'error';
@@ -84,6 +90,11 @@ class Finding {
      * @var string
      */
 	public const LAYER_TYPE = 'type';
+
+	/**
+     * @var string
+     */
+	public const LAYER_RULE = 'rule';
 
 	/**
 	 * @param string $table Table to display this finding under.

--- a/src/Utility/Association/FixSuggester.php
+++ b/src/Utility/Association/FixSuggester.php
@@ -2,6 +2,7 @@
 
 namespace TestHelper\Utility\Association;
 
+use Cake\Database\Schema\TableSchema;
 use Cake\Utility\Inflector;
 
 /**
@@ -22,21 +23,114 @@ class FixSuggester {
 
 		// A stray FK on owner -> referenced means the owner is missing a belongsTo,
 		// and the referenced table is missing the reciprocal hasMany.
+		$foreignKey = $this->columnArg($fk->columns);
+		$bindingKey = $this->bindingKeyOption($fk);
 		$belongsTo = sprintf(
-			"// On %sTable::initialize():\n\$this->belongsTo('%s', ['foreignKey' => '%s']);",
+			"// On %sTable::initialize():\n\$this->belongsTo('%s', ['foreignKey' => %s%s]);",
 			$ownerAlias,
 			$alias,
-			$fk->column,
+			$foreignKey,
+			$bindingKey,
 		);
 
 		$hasMany = sprintf(
-			"// Reciprocal, on %sTable::initialize():\n\$this->hasMany('%s', ['foreignKey' => '%s']);",
+			"// Reciprocal, on %sTable::initialize():\n\$this->hasMany('%s', ['foreignKey' => %s%s]);",
 			$alias,
 			$ownerAlias,
-			$fk->column,
+			$foreignKey,
+			$bindingKey,
 		);
 
 		return $belongsTo . "\n" . $hasMany;
+	}
+
+	/**
+	 * Migration line to align a FK column's type with its referenced (PK) column when the
+	 * two disagree. The referenced column is treated as canonical, so the FK column is the
+	 * one changed; flip it if the PK is the side that should move.
+	 *
+	 * @param \TestHelper\Utility\Association\ForeignKey $fk Code-sourced foreign key with a type mismatch.
+	 * @return string
+	 */
+	public function typeAlignmentLine(ForeignKey $fk): string {
+		return sprintf(
+			"// On the `%s` table migration: align `%s` with `%s.%s`.\n"
+			. "// changeColumn replaces the whole definition, so carry over the column's existing\n"
+			. "// null/default/limit options below or they revert to defaults.\n"
+			. "\$table->changeColumn('%s', '%s', [\n"
+			. "    // 'null' => false, 'default' => null, ...\n"
+			. ']);',
+			$fk->ownerTable,
+			$fk->column,
+			$fk->referencedTable,
+			$fk->referencedColumn,
+			$fk->column,
+			(string)$fk->referencedColumnType,
+		);
+	}
+
+	/**
+	 * Migration to align a DB FK with a `dependent` association: drop and re-add it with
+	 * `ON DELETE CASCADE` so a direct SQL delete cascades like the ORM already does. The
+	 * existing `ON UPDATE` rule is preserved so only the delete behavior changes.
+	 *
+	 * @param \TestHelper\Utility\Association\ForeignKey $fk Code-sourced foreign key.
+	 * @param string|null $onUpdate Current DB `ON UPDATE` rule (TableSchema action), preserved as-is.
+	 * @return string
+	 */
+	public function cascadeMigrationLine(ForeignKey $fk, ?string $onUpdate = null): string {
+		$columns = $this->columnArg($fk->columns);
+
+		return sprintf(
+			"// On the `%s` table migration: match the ORM's dependent cascade.\n"
+			. "\$table->dropForeignKey(%s)\n"
+			. "    ->addForeignKey(%s, '%s', %s, [\n"
+			. "        'update' => '%s', 'delete' => 'CASCADE',\n"
+			. '    ]);',
+			$fk->ownerTable,
+			$columns,
+			$columns,
+			$fk->referencedTable,
+			$this->columnArg($fk->referencedColumns),
+			$this->migrationAction($onUpdate),
+		);
+	}
+
+	/**
+	 * Association-side hint: mark the association `dependent` and `cascadeCallbacks` so the
+	 * ORM loads and deletes children (firing their callbacks) when the DB already cascades.
+	 * `dependent` alone uses a bulk `deleteAll()` that skips child callbacks.
+	 *
+	 * @param \TestHelper\Utility\Association\ForeignKey $fk Code-sourced foreign key.
+	 * @return string
+	 */
+	public function dependentOption(ForeignKey $fk): string {
+		return sprintf(
+			"// On %sTable::initialize(), if the DB cascade is intended:\n"
+			. "\$this->%s('%s', ['foreignKey' => %s%s, 'dependent' => true, 'cascadeCallbacks' => true]);",
+			$fk->declaringTable ?? Inflector::camelize($fk->referencedTable),
+			$fk->associationType ?? 'hasMany',
+			$fk->alias ?? Inflector::camelize($fk->ownerTable),
+			$this->columnArg($fk->columns),
+			$this->bindingKeyOption($fk),
+		);
+	}
+
+	/**
+	 * Map an internal TableSchema cascade-action string to the Phinx migration option value
+	 * this plugin uses (e.g. `setNull` -> `SET_NULL`). Unknown/null defaults to `NO_ACTION`.
+	 *
+	 * @param string|null $action TableSchema::ACTION_* value, or null.
+	 * @return string
+	 */
+	protected function migrationAction(?string $action): string {
+		return match ($action) {
+			TableSchema::ACTION_CASCADE => 'CASCADE',
+			TableSchema::ACTION_RESTRICT => 'RESTRICT',
+			TableSchema::ACTION_SET_NULL => 'SET_NULL',
+			TableSchema::ACTION_SET_DEFAULT => 'SET_DEFAULT',
+			default => 'NO_ACTION',
+		};
 	}
 
 	/**
@@ -47,12 +141,12 @@ class FixSuggester {
 	 */
 	public function migrationLine(ForeignKey $fk): string {
 		return sprintf(
-			"\$table->addForeignKey('%s', '%s', '%s', [\n"
+			"\$table->addForeignKey(%s, '%s', %s, [\n"
 			. "    'update' => 'NO_ACTION', 'delete' => 'NO_ACTION',\n"
 			. ']);',
-			$fk->column,
+			$this->columnArg($fk->columns),
 			$fk->referencedTable,
-			$fk->referencedColumn,
+			$this->columnArg($fk->referencedColumns),
 		);
 	}
 
@@ -66,22 +160,56 @@ class FixSuggester {
 	 * @return string
 	 */
 	public function columnLine(ForeignKey $fk): string {
+		// The first missing column carries the example addColumn; composite keys add the rest by hand.
+		$firstColumn = $fk->columns[0];
+
 		return sprintf(
 			"// `%s.%s` is missing - add it to match `%s.%s` (copy its type/length), then the constraint:\n"
 			. "\$table->addColumn('%s', '%s', ['null' => true]);\n"
-			. "\$table->addForeignKey('%s', '%s', '%s', [\n"
+			. "\$table->addForeignKey(%s, '%s', %s, [\n"
 			. "    'update' => 'NO_ACTION', 'delete' => 'NO_ACTION',\n"
 			. ']);',
 			$fk->ownerTable,
 			$fk->column,
 			$fk->referencedTable,
 			$fk->referencedColumn,
-			$fk->column,
+			$firstColumn,
 			$fk->referencedColumnType ?? 'integer',
-			$fk->column,
+			$this->columnArg($fk->columns),
 			$fk->referencedTable,
-			$fk->referencedColumn,
+			$this->columnArg($fk->referencedColumns),
 		);
+	}
+
+	/**
+	 * A `, 'bindingKey' => ...` association option, but only when the referenced column(s)
+	 * are non-default (composite, or a single column other than `id`). The default `id`
+	 * binding needs no explicit option, keeping the common snippet clean.
+	 *
+	 * @param \TestHelper\Utility\Association\ForeignKey $fk
+	 * @return string
+	 */
+	protected function bindingKeyOption(ForeignKey $fk): string {
+		if ($fk->referencedColumns === ['id']) {
+			return '';
+		}
+
+		return ", 'bindingKey' => " . $this->columnArg($fk->referencedColumns);
+	}
+
+	/**
+	 * Render FK column(s) as a migration/association argument: a quoted name for a single
+	 * column, or a bracketed array for a composite key.
+	 *
+	 * @param array<string> $columns
+	 * @return string
+	 */
+	protected function columnArg(array $columns): string {
+		if (count($columns) === 1) {
+			return "'" . $columns[0] . "'";
+		}
+
+		return "['" . implode("', '", $columns) . "']";
 	}
 
 }

--- a/src/Utility/Association/ForeignKey.php
+++ b/src/Utility/Association/ForeignKey.php
@@ -23,25 +23,56 @@ class ForeignKey {
 	public const SOURCE_CODE = 'code';
 
 	/**
+	 * Owner FK column(s), in order. A composite FK has more than one.
+	 *
+	 * @var array<string>
+	 */
+	public readonly array $columns;
+
+	/**
+	 * Referenced column(s), positionally aligned with $columns.
+	 *
+	 * @var array<string>
+	 */
+	public readonly array $referencedColumns;
+
+	/**
+	 * Display form of the owner column(s): the single name, or comma-joined for composite.
+	 *
+	 * @var string
+	 */
+	public readonly string $column;
+
+	/**
+	 * Display form of the referenced column(s).
+	 *
+	 * @var string
+	 */
+	public readonly string $referencedColumn;
+
+	/**
 	 * @param string $connection Connection name (same table name on another connection is a different target).
 	 * @param string $ownerTable Table that physically holds the FK column.
-	 * @param string $column FK column on the owner table.
+	 * @param array<string>|string $column FK column(s) on the owner table.
 	 * @param string $referencedTable Table the FK points at.
-	 * @param string $referencedColumn Referenced column (usually the PK; honors bindingKey).
+	 * @param array<string>|string $referencedColumn Referenced column(s) (usually the PK; honors bindingKey).
 	 * @param string $source self::SOURCE_DB or self::SOURCE_CODE.
 	 * @param string|null $associationType Association type for code-sourced keys.
 	 * @param string|null $declaringTable Table whose class declared the association (code-sourced).
 	 * @param string|null $alias Association alias (code-sourced).
-	 * @param bool $columnExists Whether the owner column physically exists (code-sourced).
-	 * @param string|null $ownerColumnType Abstract DB type of the owner column (code-sourced), or null if unresolved.
-	 * @param string|null $referencedColumnType Abstract DB type of the referenced column (code-sourced), or null if unresolved.
+	 * @param bool $columnExists Whether the owner column(s) physically exist (code-sourced).
+	 * @param string|null $ownerColumnType Abstract DB type of the owner column (code-sourced, single-column only), or null.
+	 * @param string|null $referencedColumnType Abstract DB type of the referenced column (code-sourced, single-column only), or null.
+	 * @param bool|null $dependent ORM cascade-delete intent (code-sourced hasMany/hasOne); null when not applicable.
+	 * @param string|null $onUpdate DB `ON UPDATE` rule (DB-sourced), or null.
+	 * @param string|null $onDelete DB `ON DELETE` rule (DB-sourced), or null.
 	 */
 	public function __construct(
 		public readonly string $connection,
 		public readonly string $ownerTable,
-		public readonly string $column,
+		array|string $column,
 		public readonly string $referencedTable,
-		public readonly string $referencedColumn,
+		array|string $referencedColumn,
 		public readonly string $source,
 		public readonly ?string $associationType = null,
 		public readonly ?string $declaringTable = null,
@@ -49,7 +80,23 @@ class ForeignKey {
 		public readonly bool $columnExists = true,
 		public readonly ?string $ownerColumnType = null,
 		public readonly ?string $referencedColumnType = null,
+		public readonly ?bool $dependent = null,
+		public readonly ?string $onUpdate = null,
+		public readonly ?string $onDelete = null,
 	) {
+		$this->columns = is_array($column) ? array_values($column) : [$column];
+		$this->referencedColumns = is_array($referencedColumn) ? array_values($referencedColumn) : [$referencedColumn];
+		$this->column = implode(', ', $this->columns);
+		$this->referencedColumn = implode(', ', $this->referencedColumns);
+	}
+
+	/**
+	 * Whether this FK spans more than one column.
+	 *
+	 * @return bool
+	 */
+	public function isComposite(): bool {
+		return count($this->columns) > 1;
 	}
 
 	/**

--- a/src/Utility/Association/JoinTableResolver.php
+++ b/src/Utility/Association/JoinTableResolver.php
@@ -36,31 +36,18 @@ class JoinTableResolver {
 			return [[], [$finding]];
 		}
 
-		$sourceForeignKey = $association->getForeignKey();
-		$targetForeignKey = $association->getTargetForeignKey();
-		if (!is_string($sourceForeignKey) || !is_string($targetForeignKey)) {
-			$finding = new Finding(
-				table: $source->getRegistryAlias(),
-				direction: Finding::DIRECTION_UNSUPPORTED,
-				associationType: 'belongsToMany',
-				severity: Finding::SEVERITY_INFO,
-				message: sprintf('belongsToMany `%s`: composite junction keys are not auto-verified.', $association->getName()),
-				target: $target->getAlias(),
-			);
-
-			return [[], [$finding]];
-		}
-
 		// Resolve referenced columns from the actual binding keys (honoring custom bindingKey).
-		$sourceBindingKey = $this->bindingColumn($association->getBindingKey(), $source->getPrimaryKey());
-		$targetBindingKey = $this->bindingColumn($this->targetBindingKey($junction, $target->getAlias()), $target->getPrimaryKey());
-		if ($sourceBindingKey === null || $targetBindingKey === null) {
+		$sourceColumns = $this->columnList($association->getForeignKey());
+		$targetColumns = $this->columnList($association->getTargetForeignKey());
+		$sourceBindingColumns = $this->bindingColumns($association->getBindingKey(), $source->getPrimaryKey());
+		$targetBindingColumns = $this->bindingColumns($this->targetBindingKey($junction, $target->getAlias()), $target->getPrimaryKey());
+		if (count($sourceColumns) !== count($sourceBindingColumns) || count($targetColumns) !== count($targetBindingColumns)) {
 			$finding = new Finding(
 				table: $source->getRegistryAlias(),
 				direction: Finding::DIRECTION_UNSUPPORTED,
 				associationType: 'belongsToMany',
 				severity: Finding::SEVERITY_INFO,
-				message: sprintf('belongsToMany `%s`: composite binding key is not auto-verified.', $association->getName()),
+				message: sprintf('belongsToMany `%s`: composite junction keys do not line up (not auto-verified).', $association->getName()),
 				target: $target->getAlias(),
 			);
 
@@ -71,35 +58,37 @@ class JoinTableResolver {
 		$junctionTable = $junction->getTable();
 		$declaringTable = $source->getRegistryAlias();
 		$junctionColumns = $this->safeColumns($junction);
+		$sourceComposite = count($sourceColumns) > 1;
+		$targetComposite = count($targetColumns) > 1;
 
 		$keys = [
 			new ForeignKey(
 				connection: $junctionConnection,
 				ownerTable: $junctionTable,
-				column: $sourceForeignKey,
+				column: $sourceColumns,
 				referencedTable: $source->getTable(),
-				referencedColumn: $sourceBindingKey,
+				referencedColumn: $sourceBindingColumns,
 				source: ForeignKey::SOURCE_CODE,
 				associationType: 'belongsToMany',
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
-				columnExists: $junctionColumns === null || in_array($sourceForeignKey, $junctionColumns, true),
-				ownerColumnType: $this->safeColumnType($junction, $sourceForeignKey),
-				referencedColumnType: $this->safeColumnType($source, $sourceBindingKey),
+				columnExists: $junctionColumns === null || !array_diff($sourceColumns, $junctionColumns),
+				ownerColumnType: $sourceComposite ? null : $this->safeColumnType($junction, $sourceColumns[0]),
+				referencedColumnType: $sourceComposite ? null : $this->safeColumnType($source, $sourceBindingColumns[0]),
 			),
 			new ForeignKey(
 				connection: $junctionConnection,
 				ownerTable: $junctionTable,
-				column: $targetForeignKey,
+				column: $targetColumns,
 				referencedTable: $target->getTable(),
-				referencedColumn: $targetBindingKey,
+				referencedColumn: $targetBindingColumns,
 				source: ForeignKey::SOURCE_CODE,
 				associationType: 'belongsToMany',
 				declaringTable: $declaringTable,
 				alias: $association->getName(),
-				columnExists: $junctionColumns === null || in_array($targetForeignKey, $junctionColumns, true),
-				ownerColumnType: $this->safeColumnType($junction, $targetForeignKey),
-				referencedColumnType: $this->safeColumnType($target, $targetBindingKey),
+				columnExists: $junctionColumns === null || !array_diff($targetColumns, $junctionColumns),
+				ownerColumnType: $targetComposite ? null : $this->safeColumnType($junction, $targetColumns[0]),
+				referencedColumnType: $targetComposite ? null : $this->safeColumnType($target, $targetBindingColumns[0]),
 			),
 		];
 
@@ -126,20 +115,31 @@ class JoinTableResolver {
 	}
 
 	/**
-	 * Resolve a single binding column. Composite (multi-column) binding keys return
-	 * null so the caller can flag the association as unsupported rather than guessing.
+	 * Normalize a junction foreign key (array/string, possibly empty) into a column list.
+	 *
+	 * @param array<int|string, string|false>|string|false $foreignKey
+	 * @return array<string>
+	 */
+	protected function columnList(array|string|false $foreignKey): array {
+		if ($foreignKey === false) {
+			return [];
+		}
+
+		return array_values(array_filter(array_map('strval', (array)$foreignKey), fn (string $c): bool => $c !== ''));
+	}
+
+	/**
+	 * Resolve the binding column(s) for one side of the junction: the explicit binding key,
+	 * falling back to the table's primary key.
 	 *
 	 * @param array<string>|string|null $bindingKey
 	 * @param array<string>|string $primaryKey
-	 * @return string|null
+	 * @return array<string>
 	 */
-	protected function bindingColumn(array|string|null $bindingKey, array|string $primaryKey): ?string {
+	protected function bindingColumns(array|string|null $bindingKey, array|string $primaryKey): array {
 		$value = $bindingKey ?: $primaryKey;
-		if (is_array($value)) {
-			return count($value) === 1 ? (string)reset($value) : null;
-		}
 
-		return $value;
+		return array_values(array_filter(array_map('strval', (array)$value), fn (string $c): bool => $c !== ''));
 	}
 
 }

--- a/src/Utility/Association/JoinTableResolver.php
+++ b/src/Utility/Association/JoinTableResolver.php
@@ -41,6 +41,20 @@ class JoinTableResolver {
 		$targetColumns = $this->columnList($association->getTargetForeignKey());
 		$sourceBindingColumns = $this->bindingColumns($association->getBindingKey(), $source->getPrimaryKey());
 		$targetBindingColumns = $this->bindingColumns($this->targetBindingKey($junction, $target->getAlias()), $target->getPrimaryKey());
+		if (!$sourceColumns || !$targetColumns) {
+			// No usable join column(s): foreignKey/targetForeignKey is false or empty, i.e. a
+			// conditions-only join rather than a composite-key misalignment.
+			$finding = new Finding(
+				table: $source->getRegistryAlias(),
+				direction: Finding::DIRECTION_UNSUPPORTED,
+				associationType: 'belongsToMany',
+				severity: Finding::SEVERITY_INFO,
+				message: sprintf('belongsToMany `%s`: has no usable join key (conditions-only join, not auto-verified).', $association->getName()),
+				target: $target->getAlias(),
+			);
+
+			return [[], [$finding]];
+		}
 		if (count($sourceColumns) !== count($sourceBindingColumns) || count($targetColumns) !== count($targetBindingColumns)) {
 			$finding = new Finding(
 				table: $source->getRegistryAlias(),

--- a/src/Utility/Association/SchemaIntrospector.php
+++ b/src/Utility/Association/SchemaIntrospector.php
@@ -28,22 +28,23 @@ class SchemaIntrospector {
 				continue;
 			}
 
-			$columns = (array)($constraint['columns'] ?? []);
+			$columns = array_map('strval', (array)($constraint['columns'] ?? []));
 			$references = $constraint['references'] ?? null;
-			if (count($columns) !== 1 || !is_array($references)) {
-				// Composite FKs are not deep-validated in v1.
+			if (!$columns || !is_array($references)) {
 				continue;
 			}
 
-			[$referencedTable, $referencedColumn] = $this->normalizeReferences($references);
+			[$referencedTable, $referencedColumns] = $this->normalizeReferences($references);
 
 			$keys[] = new ForeignKey(
 				connection: $connectionName,
 				ownerTable: $table,
-				column: (string)$columns[0],
+				column: $columns,
 				referencedTable: $referencedTable,
-				referencedColumn: $referencedColumn,
+				referencedColumn: $referencedColumns,
 				source: ForeignKey::SOURCE_DB,
+				onUpdate: isset($constraint['update']) ? (string)$constraint['update'] : null,
+				onDelete: isset($constraint['delete']) ? (string)$constraint['delete'] : null,
 			);
 		}
 
@@ -93,16 +94,18 @@ class SchemaIntrospector {
 
 	/**
 	 * @param array<int|string, mixed> $references
-	 * @return array{0: string, 1: string}
+	 * @return array{0: string, 1: array<string>}
 	 */
 	protected function normalizeReferences(array $references): array {
 		$referencedTable = (string)($references[0] ?? '');
-		$referencedColumn = $references[1] ?? 'id';
-		if (is_array($referencedColumn)) {
-			$referencedColumn = (string)(reset($referencedColumn) ?: 'id');
+		$referencedColumns = $references[1] ?? 'id';
+		$referencedColumns = is_array($referencedColumns) ? array_values($referencedColumns) : [$referencedColumns];
+		$referencedColumns = array_map('strval', $referencedColumns);
+		if (!$referencedColumns) {
+			$referencedColumns = ['id'];
 		}
 
-		return [$referencedTable, (string)$referencedColumn];
+		return [$referencedTable, $referencedColumns];
 	}
 
 }

--- a/templates/Associations/index.php
+++ b/templates/Associations/index.php
@@ -19,6 +19,15 @@ $badge = function (?string $severity): string {
 		default => 'bg-success',
 	};
 };
+
+$columnLabel = function (string $column): string {
+	return match ($column) {
+		'looseColumn' => 'Loose column',
+		'keyType' => 'Key type',
+		'cascadeRule' => 'Cascade',
+		default => $column,
+	};
+};
 ?>
 
 <div class="page-header mb-3">
@@ -54,7 +63,7 @@ $badge = function (?string $severity): string {
 				<tr>
 					<th>Table</th>
 					<?php foreach ($columns as $column) { ?>
-						<th class="text-center"><?php echo h($column); ?></th>
+						<th class="text-center"><?php echo h($columnLabel($column)); ?></th>
 					<?php } ?>
 				</tr>
 			</thead>

--- a/templates/Associations/view.php
+++ b/templates/Associations/view.php
@@ -14,6 +14,7 @@ $labels = [
 	Finding::DIRECTION_MISMATCH => ['Mismatches', 'danger'],
 	Finding::DIRECTION_COLUMN_MISSING => ['Declared, but column missing', 'danger'],
 	Finding::DIRECTION_TYPE => ['Key column types', 'dark'],
+	Finding::DIRECTION_RULE => ['Cascade rules', 'dark'],
 	Finding::DIRECTION_DB_MISSING => ['Declared, but missing DB constraint', 'warning'],
 	Finding::DIRECTION_CODE_MISSING => ['In DB, but no association', 'info'],
 	Finding::DIRECTION_UNSUPPORTED => ['Not auto-verifiable', 'secondary'],

--- a/tests/TestCase/Controller/AssociationsControllerTest.php
+++ b/tests/TestCase/Controller/AssociationsControllerTest.php
@@ -2,8 +2,10 @@
 
 namespace TestHelper\Test\TestCase\Controller;
 
+use Cake\Http\ServerRequest;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
+use TestHelper\Controller\AssociationsController;
 use TestHelper\Utility\Association\Finding;
 
 /**
@@ -25,11 +27,37 @@ class AssociationsControllerTest extends TestCase {
 
 		$this->assertResponseCode(200);
 		$this->assertResponseContains('Association');
-		$this->assertSame(['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'looseColumn'], $this->viewVariable('columns'));
+		$this->assertSame(['belongsTo', 'hasMany', 'hasOne', 'belongsToMany', 'looseColumn', 'keyType', 'cascadeRule'], $this->viewVariable('columns'));
 		$this->assertIsArray($this->viewVariable('matrix'));
 		$this->assertIsArray($this->viewVariable('tables'));
 		$this->assertSame(['error', 'warning', 'info'], array_keys($this->viewVariable('totals')));
 		$this->assertFalse($this->viewVariable('includeVendor'));
+	}
+
+	/**
+	 * Cross-cutting layers route to their own matrix columns; everything else stays under
+	 * its association type.
+	 *
+	 * @return void
+	 */
+	public function testColumnForRoutesLayersToOwnColumns() {
+		$controller = new class (new ServerRequest()) extends AssociationsController {
+
+			public function columnForPublic(Finding $finding): string {
+				return $this->columnFor($finding);
+			}
+
+		};
+
+		$type = new Finding('Posts', Finding::DIRECTION_TYPE, 'belongsTo', Finding::SEVERITY_ERROR, 'm', layer: Finding::LAYER_TYPE);
+		$rule = new Finding('Posts', Finding::DIRECTION_RULE, 'hasMany', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_RULE);
+		$constraint = new Finding('Posts', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'm', layer: Finding::LAYER_CONSTRAINT);
+		$loose = new Finding('Posts', Finding::DIRECTION_CODE_MISSING, 'looseColumn', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_COLUMN);
+
+		$this->assertSame('keyType', $controller->columnForPublic($type));
+		$this->assertSame('cascadeRule', $controller->columnForPublic($rule));
+		$this->assertSame('belongsTo', $controller->columnForPublic($constraint));
+		$this->assertSame('looseColumn', $controller->columnForPublic($loose));
 	}
 
 	/**

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -357,6 +357,18 @@ class AssociationAuditorTest extends TestCase {
 	}
 
 	/**
+	 * A type mismatch carries a changeColumn fix aligning the FK column to its target.
+	 *
+	 * @return void
+	 */
+	public function testTypeMismatchCarriesFixSnippet() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'uuid')]);
+
+		$this->assertCount(1, $findings);
+		$this->assertStringContainsString("\$table->changeColumn('author_id', 'uuid', [", (string)$findings[0]->fixSnippet);
+	}
+
+	/**
 	 * Matching non-integer types (both uuid) are info, since integer is preferred.
 	 *
 	 * @return void
@@ -368,6 +380,41 @@ class AssociationAuditorTest extends TestCase {
 		$this->assertSame(Finding::DIRECTION_TYPE, $findings[0]->direction);
 		$this->assertSame(Finding::SEVERITY_INFO, $findings[0]->severity);
 		$this->assertStringContainsString('non-integer', $findings[0]->message);
+	}
+
+	/**
+	 * The non-integer info advisory is not an actionable migration, so it carries no fix.
+	 *
+	 * @return void
+	 */
+	public function testTypeInfoHasNoFixSnippet() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('uuid', 'uuid')]);
+
+		$this->assertCount(1, $findings);
+		$this->assertNull($findings[0]->fixSnippet);
+	}
+
+	/**
+	 * With preferIntegerKeys off, the non-integer info advisory is suppressed.
+	 *
+	 * @return void
+	 */
+	public function testTypePreferIntegerKeysSuppressesInfo() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('uuid', 'uuid')], false);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * Even with preferIntegerKeys off, a real cross-type mismatch is still an error.
+	 *
+	 * @return void
+	 */
+	public function testTypeMismatchStillErrorsWhenPreferIntegerKeysOff() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'uuid')], false);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::SEVERITY_ERROR, $findings[0]->severity);
 	}
 
 	/**
@@ -395,6 +442,140 @@ class AssociationAuditorTest extends TestCase {
 		$findings = $this->auditor->typeFindings($keys);
 
 		$this->assertCount(1, $findings);
+	}
+
+	/**
+	 * A dependent association whose DB FK does not cascade is an info rule finding with a fix.
+	 *
+	 * @return void
+	 */
+	public function testRuleDependentButDbDoesNotCascade() {
+		$findings = $this->auditor->ruleFindings(
+			[$this->dependentKey(true, 'hasMany')],
+			[$this->dbRuleKey('noAction')],
+		);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_RULE, $findings[0]->direction);
+		$this->assertSame(Finding::SEVERITY_INFO, $findings[0]->severity);
+		$this->assertStringContainsString('cascade', strtolower($findings[0]->message));
+		$this->assertStringContainsString('addForeignKey', (string)$findings[0]->fixSnippet);
+	}
+
+	/**
+	 * A dependent association backed by ON DELETE CASCADE is consistent: no finding.
+	 *
+	 * @return void
+	 */
+	public function testRuleDependentAndDbCascadesClean() {
+		$findings = $this->auditor->ruleFindings(
+			[$this->dependentKey(true, 'hasMany')],
+			[$this->dbRuleKey('cascade')],
+		);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * A DB cascade with a non-dependent association is flagged: the ORM won't fire callbacks.
+	 *
+	 * @return void
+	 */
+	public function testRuleDbCascadesButNotDependent() {
+		$findings = $this->auditor->ruleFindings(
+			[$this->dependentKey(false, 'hasMany')],
+			[$this->dbRuleKey('cascade')],
+		);
+
+		$this->assertCount(1, $findings);
+		$this->assertSame(Finding::DIRECTION_RULE, $findings[0]->direction);
+		$this->assertStringContainsString('dependent', strtolower($findings[0]->message));
+	}
+
+	/**
+	 * With no matching DB FK there is nothing to compare against (constraint layer covers it).
+	 *
+	 * @return void
+	 */
+	public function testRuleNoDbFkSkipped() {
+		$findings = $this->auditor->ruleFindings([$this->dependentKey(true, 'hasMany')], []);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * belongsTo carries no dependent intent, so it is never rule-checked.
+	 *
+	 * @return void
+	 */
+	public function testRuleBelongsToSkipped() {
+		$findings = $this->auditor->ruleFindings(
+			[$this->dependentKey(null, 'belongsTo')],
+			[$this->dbRuleKey('cascade')],
+		);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
+	 * Two hasMany aliases on the same FK with different dependent settings are checked
+	 * independently; the dependent intent of a later alias must not be dropped by dedupe.
+	 *
+	 * @return void
+	 */
+	public function testRuleChecksEachAliasIndependently() {
+		$findings = $this->auditor->ruleFindings(
+			[
+				$this->dependentKey(true, 'hasMany', 'Comments'),
+				$this->dependentKey(false, 'hasMany', 'ApprovedComments'),
+			],
+			[$this->dbRuleKey('cascade')],
+		);
+
+		// dependent=true + cascade is consistent; dependent=false + cascade is flagged.
+		$this->assertCount(1, $findings);
+		$this->assertStringContainsString('ApprovedComments', $findings[0]->message);
+	}
+
+	/**
+	 * Build a code-sourced ForeignKey carrying a dependent intent.
+	 *
+	 * @param bool|null $dependent
+	 * @param string $associationType
+	 * @param string $alias
+	 * @return \TestHelper\Utility\Association\ForeignKey
+	 */
+	protected function dependentKey(?bool $dependent, string $associationType, string $alias = 'Comments'): ForeignKey {
+		return new ForeignKey(
+			connection: 'default',
+			ownerTable: 'comments',
+			column: 'post_id',
+			referencedTable: 'posts',
+			referencedColumn: 'id',
+			source: ForeignKey::SOURCE_CODE,
+			associationType: $associationType,
+			declaringTable: 'Posts',
+			alias: $alias,
+			dependent: $dependent,
+		);
+	}
+
+	/**
+	 * Build a DB-sourced ForeignKey carrying an ON DELETE rule, matching dependentKey().
+	 *
+	 * @param string $onDelete
+	 * @return \TestHelper\Utility\Association\ForeignKey
+	 */
+	protected function dbRuleKey(string $onDelete): ForeignKey {
+		return new ForeignKey(
+			connection: 'default',
+			ownerTable: 'comments',
+			column: 'post_id',
+			referencedTable: 'posts',
+			referencedColumn: 'id',
+			source: ForeignKey::SOURCE_DB,
+			onDelete: $onDelete,
+		);
 	}
 
 	/**

--- a/tests/TestCase/Utility/Association/AssociationReaderTest.php
+++ b/tests/TestCase/Utility/Association/AssociationReaderTest.php
@@ -138,6 +138,106 @@ class AssociationReaderTest extends TestCase {
 	}
 
 	/**
+	 * hasMany carries the ORM `dependent` intent onto the foreign key.
+	 *
+	 * @return void
+	 */
+	public function testHasManyCapturesDependent() {
+		$authors = $this->table('Authors', 'authors', ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']]);
+		$this->table('Posts', 'posts', ['id' => ['type' => 'integer'], 'author_id' => ['type' => 'integer']]);
+		$authors->hasMany('Posts', ['foreignKey' => 'author_id', 'dependent' => true]);
+
+		[$keys] = $this->reader->read($authors);
+
+		$this->assertCount(1, $keys);
+		$this->assertTrue($keys[0]->dependent);
+	}
+
+	/**
+	 * belongsTo has no dependent concept, so the intent stays null (rule layer skips it).
+	 *
+	 * @return void
+	 */
+	public function testBelongsToHasNullDependent() {
+		$this->table('Authors', 'authors', ['id' => ['type' => 'integer'], 'name' => ['type' => 'string']]);
+		$posts = $this->table('Posts', 'posts', ['id' => ['type' => 'integer'], 'author_id' => ['type' => 'integer']]);
+		$posts->belongsTo('Authors', ['foreignKey' => 'author_id']);
+
+		[$keys] = $this->reader->read($posts);
+
+		$this->assertCount(1, $keys);
+		$this->assertNull($keys[0]->dependent);
+	}
+
+	/**
+	 * A composite belongsTo normalizes to ordered column arrays instead of being skipped.
+	 *
+	 * @return void
+	 */
+	public function testCompositeBelongsToNormalizesToArrayColumns() {
+		$this->table('Companies', 'companies', [
+			'tenant_id' => ['type' => 'integer'],
+			'id' => ['type' => 'integer'],
+			'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['tenant_id', 'id']]],
+		]);
+		$memberships = $this->table('Memberships', 'memberships', [
+			'id' => ['type' => 'integer'],
+			'tenant_id' => ['type' => 'integer'],
+			'company_id' => ['type' => 'integer'],
+		]);
+		$memberships->belongsTo('Companies', [
+			'foreignKey' => ['tenant_id', 'company_id'],
+			'bindingKey' => ['tenant_id', 'id'],
+		]);
+
+		[$keys, $unsupported] = $this->reader->read($memberships);
+
+		$this->assertSame([], $unsupported);
+		$this->assertCount(1, $keys);
+		$this->assertSame(['tenant_id', 'company_id'], $keys[0]->columns);
+		$this->assertSame(['tenant_id', 'id'], $keys[0]->referencedColumns);
+		$this->assertTrue($keys[0]->isComposite());
+	}
+
+	/**
+	 * A composite belongsToMany resolves both junction FKs as ordered column arrays.
+	 *
+	 * @return void
+	 */
+	public function testCompositeBelongsToManyExpandsToArrayColumns() {
+		$articles = $this->table('Articles', 'articles', [
+			'tenant_id' => ['type' => 'integer'],
+			'id' => ['type' => 'integer'],
+			'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['tenant_id', 'id']]],
+		]);
+		$this->table('Tags', 'tags', [
+			'tenant_id' => ['type' => 'integer'],
+			'id' => ['type' => 'integer'],
+			'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['tenant_id', 'id']]],
+		]);
+		$this->table('ArticlesTags', 'articles_tags', [
+			'id' => ['type' => 'integer'],
+			'tenant_id' => ['type' => 'integer'],
+			'article_id' => ['type' => 'integer'],
+			'tag_id' => ['type' => 'integer'],
+		]);
+		$articles->belongsToMany('Tags', [
+			'joinTable' => 'articles_tags',
+			'foreignKey' => ['tenant_id', 'article_id'],
+			'targetForeignKey' => ['tenant_id', 'tag_id'],
+			'bindingKey' => ['tenant_id', 'id'],
+		]);
+
+		[$keys, $unsupported] = $this->reader->read($articles);
+
+		$this->assertSame([], $unsupported);
+		$this->assertCount(2, $keys);
+		$this->assertSame(['tenant_id', 'article_id'], $keys[0]->columns);
+		$this->assertSame(['tenant_id', 'id'], $keys[0]->referencedColumns);
+		$this->assertTrue($keys[0]->isComposite());
+	}
+
+	/**
 	 * belongsToMany expands into two junction-table foreign keys.
 	 *
 	 * @return void
@@ -188,11 +288,12 @@ class AssociationReaderTest extends TestCase {
 	}
 
 	/**
-	 * A composite binding key on belongsToMany is flagged unsupported, not truncated.
+	 * A belongsToMany whose FK columns and binding columns don't line up (here a single
+	 * junction FK against a composite source PK) is flagged unsupported, not truncated.
 	 *
 	 * @return void
 	 */
-	public function testBelongsToManyCompositeBindingKeyIsUnsupported() {
+	public function testBelongsToManyMismatchedKeysAreUnsupported() {
 		$articles = $this->table('Articles', 'articles', [
 			'id' => ['type' => 'integer'],
 			'sub' => ['type' => 'integer'],
@@ -211,7 +312,7 @@ class AssociationReaderTest extends TestCase {
 		$this->assertSame([], $keys);
 		$this->assertCount(1, $unsupported);
 		$this->assertSame('unsupported', $unsupported[0]->direction);
-		$this->assertStringContainsString('composite binding key', $unsupported[0]->message);
+		$this->assertStringContainsString('do not line up', $unsupported[0]->message);
 	}
 
 	/**

--- a/tests/TestCase/Utility/Association/FixSuggesterTest.php
+++ b/tests/TestCase/Utility/Association/FixSuggesterTest.php
@@ -42,4 +42,118 @@ class FixSuggesterTest extends TestCase {
 		$this->assertStringContainsString("\$table->addForeignKey('author_id', 'authors', 'id'", $result);
 	}
 
+	/**
+	 * A composite FK renders its columns as arrays in the migration line.
+	 *
+	 * @return void
+	 */
+	public function testMigrationLineComposite() {
+		$fk = new ForeignKey('default', 'memberships', ['tenant_id', 'company_id'], 'companies', ['tenant_id', 'id'], ForeignKey::SOURCE_CODE, 'belongsTo', 'Memberships', 'Companies', true);
+
+		$result = $this->suggester->migrationLine($fk);
+
+		$this->assertStringContainsString("\$table->addForeignKey(['tenant_id', 'company_id'], 'companies', ['tenant_id', 'id']", $result);
+	}
+
+	/**
+	 * A composite stray FK suggests a belongsTo with an array foreignKey.
+	 *
+	 * @return void
+	 */
+	public function testAssociationCallComposite() {
+		$fk = new ForeignKey('default', 'memberships', ['tenant_id', 'company_id'], 'companies', ['tenant_id', 'id'], ForeignKey::SOURCE_DB);
+
+		$result = $this->suggester->associationCall($fk);
+
+		$this->assertStringContainsString("'foreignKey' => ['tenant_id', 'company_id']", $result);
+		// Composite/non-default referenced columns must be pinned with bindingKey.
+		$this->assertStringContainsString("'bindingKey' => ['tenant_id', 'id']", $result);
+	}
+
+	/**
+	 * A FK referencing the plain `id` PK needs no explicit bindingKey.
+	 *
+	 * @return void
+	 */
+	public function testAssociationCallDefaultIdNeedsNoBindingKey() {
+		$fk = new ForeignKey('default', 'posts', 'author_id', 'authors', 'id', ForeignKey::SOURCE_DB);
+
+		$result = $this->suggester->associationCall($fk);
+
+		$this->assertStringNotContainsString('bindingKey', $result);
+	}
+
+	/**
+	 * The fix aligns the FK column to its referenced (PK) column's type.
+	 *
+	 * @return void
+	 */
+	public function testTypeAlignmentLine() {
+		$fk = new ForeignKey('default', 'posts', 'author_id', 'authors', 'id', ForeignKey::SOURCE_CODE, 'belongsTo', 'Posts', 'Authors', true, 'integer', 'uuid');
+
+		$result = $this->suggester->typeAlignmentLine($fk);
+
+		$this->assertStringContainsString("\$table->changeColumn('author_id', 'uuid', [", $result);
+		$this->assertStringContainsString('authors.id', $result);
+		// changeColumn replaces the whole definition; the snippet must warn about preserving options.
+		$this->assertStringContainsString('null', $result);
+	}
+
+	/**
+	 * The cascade fix preserves the FK's existing ON UPDATE rule instead of forcing NO_ACTION.
+	 *
+	 * @return void
+	 */
+	public function testCascadeMigrationLinePreservesExistingUpdateRule() {
+		$fk = new ForeignKey('default', 'comments', 'post_id', 'posts', 'id', ForeignKey::SOURCE_CODE, 'hasMany', 'Posts', 'Comments');
+
+		$result = $this->suggester->cascadeMigrationLine($fk, 'cascade');
+
+		$this->assertStringContainsString("'delete' => 'CASCADE'", $result);
+		$this->assertStringContainsString("'update' => 'CASCADE'", $result);
+	}
+
+	/**
+	 * Without a known current rule the cascade fix defaults ON UPDATE to NO_ACTION.
+	 *
+	 * @return void
+	 */
+	public function testCascadeMigrationLineDefaultsUpdateToNoAction() {
+		$fk = new ForeignKey('default', 'comments', 'post_id', 'posts', 'id', ForeignKey::SOURCE_CODE, 'hasMany', 'Posts', 'Comments');
+
+		$result = $this->suggester->cascadeMigrationLine($fk);
+
+		$this->assertStringContainsString("'update' => 'NO_ACTION'", $result);
+		$this->assertStringContainsString("'delete' => 'CASCADE'", $result);
+	}
+
+	/**
+	 * The dependent-option fix sets cascadeCallbacks too, since dependent alone skips callbacks.
+	 *
+	 * @return void
+	 */
+	public function testDependentOptionEnablesCascadeCallbacks() {
+		$fk = new ForeignKey('default', 'comments', 'post_id', 'posts', 'id', ForeignKey::SOURCE_CODE, 'hasMany', 'Posts', 'Comments');
+
+		$result = $this->suggester->dependentOption($fk);
+
+		$this->assertStringContainsString("'dependent' => true", $result);
+		$this->assertStringContainsString("'cascadeCallbacks' => true", $result);
+		// Default id binding needs no explicit bindingKey.
+		$this->assertStringNotContainsString('bindingKey', $result);
+	}
+
+	/**
+	 * The dependent fix preserves a non-default binding key so it isn't dropped on paste.
+	 *
+	 * @return void
+	 */
+	public function testDependentOptionPreservesCustomBindingKey() {
+		$fk = new ForeignKey('default', 'comments', 'post_uuid', 'posts', 'uuid', ForeignKey::SOURCE_CODE, 'hasMany', 'Posts', 'Comments');
+
+		$result = $this->suggester->dependentOption($fk);
+
+		$this->assertStringContainsString("'bindingKey' => 'uuid'", $result);
+	}
+
 }

--- a/tests/TestCase/Utility/Association/ForeignKeyTest.php
+++ b/tests/TestCase/Utility/Association/ForeignKeyTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Utility\Association;
+
+use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\ForeignKey;
+
+class ForeignKeyTest extends TestCase {
+
+	/**
+	 * A composite FK exposes its columns as ordered arrays plus a joined display form.
+	 *
+	 * @return void
+	 */
+	public function testCompositeColumnsExposedAsArrays() {
+		$fk = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_DB);
+
+		$this->assertSame(['tenant_id', 'user_id'], $fk->columns);
+		$this->assertSame(['tenant_id', 'id'], $fk->referencedColumns);
+		$this->assertSame('tenant_id, user_id', $fk->column);
+		$this->assertSame('tenant_id, id', $fk->referencedColumn);
+		$this->assertTrue($fk->isComposite());
+	}
+
+	/**
+	 * A single-column FK keeps the string accessors and is not composite (backward compat).
+	 *
+	 * @return void
+	 */
+	public function testSingleColumnBackwardCompatible() {
+		$fk = new ForeignKey('default', 'posts', 'author_id', 'authors', 'id', ForeignKey::SOURCE_DB);
+
+		$this->assertSame(['author_id'], $fk->columns);
+		$this->assertSame('author_id', $fk->column);
+		$this->assertSame('id', $fk->referencedColumn);
+		$this->assertFalse($fk->isComposite());
+	}
+
+	/**
+	 * The identity key folds the ordered columns in, so composite keys compare correctly.
+	 *
+	 * @return void
+	 */
+	public function testCompositeKeyIdentity() {
+		$a = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_CODE);
+		$b = new ForeignKey('default', 'memberships', ['tenant_id', 'user_id'], 'users', ['tenant_id', 'id'], ForeignKey::SOURCE_DB);
+
+		$this->assertSame($a->key(), $b->key());
+	}
+
+}

--- a/tests/TestCase/Utility/Association/SchemaIntrospectorTest.php
+++ b/tests/TestCase/Utility/Association/SchemaIntrospectorTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace TestHelper\Test\TestCase\Utility\Association;
+
+use Cake\Database\Connection;
+use Cake\Database\Schema\TableSchema;
+use Cake\Datasource\ConnectionManager;
+use Cake\TestSuite\TestCase;
+use TestHelper\Utility\Association\SchemaIntrospector;
+use Throwable;
+
+class SchemaIntrospectorTest extends TestCase {
+
+	protected Connection $connection;
+
+	protected SchemaIntrospector $introspector;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		$connection = ConnectionManager::get('test');
+		if (!$connection instanceof Connection) {
+			$this->markTestSkipped('Test connection is not a database connection.');
+		}
+		$this->connection = $connection;
+		$this->introspector = new SchemaIntrospector();
+
+		$this->dropTables();
+		$this->createTables();
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$this->dropTables();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The introspector captures the real ON DELETE / ON UPDATE rule of a DB foreign key.
+	 *
+	 * @return void
+	 */
+	public function testForeignKeysCaptureCascadeRules() {
+		$keys = $this->introspector->foreignKeys($this->connection, 'th_audit_children');
+
+		$this->assertCount(1, $keys);
+		$key = $keys[0];
+		$this->assertSame('parent_id', $key->column);
+		$this->assertSame('th_audit_parents', $key->referencedTable);
+		$this->assertSame(TableSchema::ACTION_CASCADE, $key->onDelete);
+	}
+
+	/**
+	 * A composite foreign key is introspected as ordered column arrays, not skipped.
+	 *
+	 * @return void
+	 */
+	public function testForeignKeysCaptureCompositeColumns() {
+		$this->createCompositeTables();
+
+		$keys = $this->introspector->foreignKeys($this->connection, 'th_audit_memberships');
+
+		$this->assertCount(1, $keys);
+		$this->assertSame(['region', 'parent_code'], $keys[0]->columns);
+		$this->assertSame('th_audit_cparents', $keys[0]->referencedTable);
+		$this->assertSame(['region', 'code'], $keys[0]->referencedColumns);
+		$this->assertTrue($keys[0]->isComposite());
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function createTables(): void {
+		$parents = (new TableSchema('th_audit_parents'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+
+		$children = (new TableSchema('th_audit_children'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addColumn('parent_id', ['type' => 'integer', 'null' => true])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']])
+			->addConstraint('fk_audit_parent', [
+				'type' => 'foreign',
+				'columns' => ['parent_id'],
+				'references' => ['th_audit_parents', 'id'],
+				'delete' => TableSchema::ACTION_CASCADE,
+				'update' => TableSchema::ACTION_NO_ACTION,
+			]);
+
+		foreach ($parents->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+		foreach ($children->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function createCompositeTables(): void {
+		$parents = (new TableSchema('th_audit_cparents'))
+			->addColumn('region', ['type' => 'integer', 'null' => false])
+			->addColumn('code', ['type' => 'integer', 'null' => false])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['region', 'code']]);
+
+		$memberships = (new TableSchema('th_audit_memberships'))
+			->addColumn('id', ['type' => 'integer', 'null' => false])
+			->addColumn('region', ['type' => 'integer', 'null' => true])
+			->addColumn('parent_code', ['type' => 'integer', 'null' => true])
+			->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']])
+			->addConstraint('fk_audit_membership', [
+				'type' => 'foreign',
+				'columns' => ['region', 'parent_code'],
+				'references' => ['th_audit_cparents', ['region', 'code']],
+				'delete' => TableSchema::ACTION_NO_ACTION,
+				'update' => TableSchema::ACTION_NO_ACTION,
+			]);
+
+		foreach ($parents->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+		foreach ($memberships->createSql($this->connection) as $sql) {
+			$this->connection->execute($sql);
+		}
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function dropTables(): void {
+		foreach (['th_audit_children', 'th_audit_memberships', 'th_audit_parents', 'th_audit_cparents'] as $table) {
+			$schema = new TableSchema($table);
+			foreach ($schema->dropSql($this->connection) as $sql) {
+				try {
+					$this->connection->execute($sql);
+				} catch (Throwable $e) {
+					// Table may not exist yet; ignore.
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Four enhancements to the association vs DB foreign-key audit (`/test-helper/associations`). All four were previously prototyped against an older base and are re-ported onto the current `master` structure (shared `SchemaColumnAccessTrait`, the narrowing rule, the column-missing/missing-constraint split, and the renamed `config/app.example.php`).

## Features

### Type-mismatch fix snippet
A cross-type key error (e.g. `integer` referencing `uuid`) now carries a `changeColumn()` migration line that aligns the FK column to its referenced (PK) type. The snippet warns that `changeColumn` replaces the whole column definition, so existing null/default/limit options must be carried over or they revert to defaults.

### Cascade-rule layer
Compares the ORM `dependent` intent of a `hasMany`/`hasOne` against the matching DB foreign key's `ON DELETE` rule (info-level, since either side can legitimately own the cascade):

- a `dependent` association whose DB FK uses `ON DELETE NO ACTION` won't cascade a delete issued directly in SQL: suggests switching the FK to `ON DELETE CASCADE`, preserving the existing `ON UPDATE` rule
- a DB `ON DELETE CASCADE` with a non-`dependent` association means the ORM won't fire child callbacks: suggests adding `'dependent' => true, 'cascadeCallbacks' => true` (both are needed, since `dependent` alone uses a bulk `deleteAll()` that skips child callbacks)

Each association is checked independently (not deduped by FK identity), so two aliases sharing one physical FK with different `dependent` settings are both evaluated. `ON UPDATE` has no ORM equivalent and is not compared.

### Composite foreign keys
`ForeignKey` now stores ordered `columns` / `referencedColumns` arrays (constructor accepts array or string and normalizes), keeps comma-joined `column` / `referencedColumn` display strings for backward compatibility, and exposes `isComposite()`. The introspector, reader and junction resolver all handle multi-column constraints; composite keys carry null column types so the key-type and narrowing layers skip them. Fix snippets render columns as arrays and pin a non-default `bindingKey`. A composite association whose FK and binding columns don't line up is reported as not auto-verifiable rather than guessed at.

### Matrix layer columns
`Key type` and `Cascade` become their own matrix columns via a `columnFor()` router (the layer routes to its own column; everything else stays under its association type), with friendly headers in the template.

## Narrowing reconciliation
`master` already flags an integer FK narrower than its referenced PK as a warning. I attached the same `changeColumn()` alignment snippet to that warning as well, since widening the column to its referenced integer type is exactly the right migration there. The cross-type error and the narrowing warning therefore share one fix path.

## Intentionally dropped
The `preferIntegerKeys` opt-out is already on `master` (`AssociationAuditor::preferIntegerKeys()` plus the `config/app.example.php` entry), so it is not re-added. `typeFindings()` gained an optional `?bool $preferIntegerKeys` parameter that falls back to the config when null, preserving the existing public contract.

Docs: the inline audit section in `docs/README.md` is updated to describe the cascade-rule layer, composite keys, and the two new matrix columns.
