### PR TITLE
Add optional back-to-app link to the TestHelper navbar

### DIFF
--- a/config/app.example.php
+++ b/config/app.example.php
@@ -10,6 +10,12 @@ return [
 		// when using the CakePHP Authorization plugin
 		'ignoreAuthorization' => true,
 
+		// Optional "back" link shown in the TestHelper navbar, for returning to your app's
+		// admin area. Accepts anything Router::url() takes (URL array, path string, full URL).
+		// Use 'plugin' => false to anchor the URL to the host app rather than TestHelper.
+		// 'adminBackUrl' => ['plugin' => false, 'prefix' => 'Admin', 'controller' => 'Overview', 'action' => 'index'],
+		// 'adminBackLabel' => 'Back to admin', // Optional. Defaults to "Back to App".
+
 		// Custom migration order for drift-check (like Migrator's runMany format).
 		// Use [] for app migrations. Order matters for foreign key constraints.
 		// If not set, auto-detects: plugins first (alphabetically), then app.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,9 @@ Browse `/test-helper` to see all functionality available.
 The default template ships with bootstrap (5) and fontawesome icons.
 You can switch out the view templates with your own on project level as documented in the CakePHP docs.
 
+### Back-to-app link
+Set `TestHelper.adminBackUrl` to show a "back" link in the TestHelper navbar that returns to your app's admin area. It accepts anything `Router::url()` takes; use `'plugin' => false` to anchor it to the host app. Customize the text with `TestHelper.adminBackLabel` (defaults to "Back to App"). See `config/app.example.php`.
+
 ## Test Runner
 Select the app or plugins, the type of classes you want to test and then click on the "run icon" to test.
 If there is no test file yet, there should be a "add icon" to click which bakes one for you.

--- a/templates/layout/test_helper.php
+++ b/templates/layout/test_helper.php
@@ -106,6 +106,15 @@
 						<?php echo $this->Html->link('Migrations', ['plugin' => 'TestHelper', 'controller' => 'Migrations', 'action' => 'index'], ['class' => 'nav-link']); ?>
 					</li>
 				</ul>
+				<?php
+				$adminBackUrl = \Cake\Core\Configure::read('TestHelper.adminBackUrl');
+				$adminBackLabel = (string)\Cake\Core\Configure::read('TestHelper.adminBackLabel', 'Back to App');
+				?>
+				<?php if ($adminBackUrl !== null && $adminBackUrl !== '') { ?>
+					<a class="btn btn-outline-light btn-sm ms-auto" href="<?php echo $this->Url->build($adminBackUrl); ?>">
+						<i class="fas fa-arrow-left me-1"></i><?php echo h($adminBackLabel); ?>
+					</a>
+				<?php } ?>
 			</div>
 		</div>
 	</nav>

--- a/tests/TestCase/Controller/TestHelperControllerTest.php
+++ b/tests/TestCase/Controller/TestHelperControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace TestHelper\Test\TestCase\Controller;
 
+use Cake\Core\Configure;
 use Cake\TestSuite\IntegrationTestTrait;
 use Cake\TestSuite\TestCase;
 
@@ -19,6 +20,39 @@ class TestHelperControllerTest extends TestCase {
 		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
 
 		$this->assertResponseCode(200);
+	}
+
+	/**
+	 * Without the config, no admin back link is rendered in the layout.
+	 *
+	 * @return void
+	 */
+	public function testAdminBackLinkHidden() {
+		Configure::delete('TestHelper.adminBackUrl');
+
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+
+		$this->assertResponseCode(200);
+		$this->assertResponseNotContains('fa-arrow-left');
+	}
+
+	/**
+	 * With adminBackUrl set, the layout renders a back link with the configured label.
+	 *
+	 * @return void
+	 */
+	public function testAdminBackLinkShown() {
+		Configure::write('TestHelper.adminBackUrl', '/admin');
+		Configure::write('TestHelper.adminBackLabel', 'Back to dashboard');
+
+		$this->get(['plugin' => 'TestHelper', 'controller' => 'TestHelper', 'action' => 'index']);
+
+		Configure::delete('TestHelper.adminBackUrl');
+		Configure::delete('TestHelper.adminBackLabel');
+
+		$this->assertResponseCode(200);
+		$this->assertResponseContains('Back to dashboard');
+		$this->assertResponseContains('fa-arrow-left');
 	}
 
 	/**


### PR DESCRIPTION
Adds an optional "back to app" link in the TestHelper navbar, so the plugin's standalone UI can return you to your application's admin area — the same affordance cakephp-queue (`adminLayout`) and cakephp-translate (`adminBackUrl`) provide.

## What

- **`TestHelper.adminBackUrl`** — when set, renders a back button in the navbar (right-aligned). Accepts anything `Router::url()` takes (URL array, path string, full URL); use `'plugin' => false` to anchor it to the host app rather than the plugin. Unset/`null` = no link (unchanged default).
- **`TestHelper.adminBackLabel`** — optional label, defaults to `"Back to App"`.

## Notes

- Documented in `config/app.example.php` (canonical) and the README Configuration section.
- Covered by shown/hidden integration tests on the home page.
- No behavior change when the config isn't set.
