### PR TITLE
Point composer homepage at the documentation site

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 			"role": "Author"
 		}
 	],
-	"homepage": "https://github.com/dereuromark/cakephp-test-helper",
+	"homepage": "https://dereuromark.github.io/cakephp-test-helper/",
 	"require": {
 		"php": ">=8.2",
 		"cakephp/cakephp": "^5.1.1"


### PR DESCRIPTION
Update the package `homepage` from the GitHub repo to the VitePress documentation site now that it exists: https://dereuromark.github.io/cakephp-test-helper/

The author homepage and repo links are unchanged.