### PR TITLE
Fix flat-scan topic filter for the cascade and index layers

### DIFF
--- a/src/Utility/Association/Finding.php
+++ b/src/Utility/Association/Finding.php
@@ -144,6 +144,24 @@ class Finding {
 	}
 
 	/**
+	 * Display labels for every value topic() can return, used by the flat-scan topic filter.
+	 * Single source of truth: every layer (plus the unsupported direction) must have a label
+	 * here, otherwise that category becomes unfilterable in the UI. FindingTest enforces this.
+	 *
+	 * @return array<string, string>
+	 */
+	public static function topicLabels(): array {
+		return [
+			static::LAYER_CONSTRAINT => 'Constraints',
+			static::LAYER_COLUMN => 'Columns',
+			static::LAYER_TYPE => 'Key types',
+			static::LAYER_RULE => 'Cascade rules',
+			static::LAYER_INDEX => 'Indexes',
+			static::DIRECTION_UNSUPPORTED => 'Not verifiable',
+		];
+	}
+
+	/**
 	 * @return array<string, mixed>
 	 */
 	public function toArray(): array {

--- a/templates/Associations/scan.php
+++ b/templates/Associations/scan.php
@@ -18,12 +18,7 @@ $rowClass = function (string $severity): string {
 	};
 };
 
-$topicLabels = [
-	Finding::LAYER_CONSTRAINT => 'Constraints',
-	Finding::LAYER_COLUMN => 'Columns',
-	Finding::LAYER_TYPE => 'Key types',
-	Finding::DIRECTION_UNSUPPORTED => 'Not verifiable',
-];
+$topicLabels = Finding::topicLabels();
 $topicCounts = array_count_values(array_map(fn (Finding $finding): string => $finding->topic(), $findings));
 ?>
 
@@ -42,17 +37,18 @@ $topicCounts = array_count_values(array_map(fn (Finding $finding): string => $fi
 
 <?php if ($findings) { ?>
 	<div class="d-flex gap-2 mb-3 flex-wrap align-items-center" id="topicFilter">
-		<span class="text-muted small">Filter by topic:</span>
+		<span class="text-muted small">Show only:</span>
 		<?php foreach ($topicLabels as $topic => $label) {
 			$count = $topicCounts[$topic] ?? 0;
 			if (!$count) {
 				continue;
 			}
 			?>
-			<button type="button" class="btn btn-sm btn-outline-secondary active topic-chip" data-topic="<?php echo h($topic); ?>" aria-pressed="true">
+			<button type="button" class="btn btn-sm btn-outline-secondary topic-chip" data-topic="<?php echo h($topic); ?>" aria-pressed="false">
 				<?php echo h($label); ?> <span class="badge bg-secondary"><?php echo $count; ?></span>
 			</button>
 		<?php } ?>
+		<span class="text-muted small fst-italic">none selected = all shown</span>
 	</div>
 <?php } ?>
 
@@ -97,18 +93,24 @@ document.addEventListener('DOMContentLoaded', function () {
 		return;
 	}
 	var rows = document.querySelectorAll('table tbody tr[data-topic]');
-	var off = {};
+	var selected = new Set();
 	function apply() {
 		rows.forEach(function (row) {
-			row.style.display = off[row.getAttribute('data-topic')] ? 'none' : '';
+			var topic = row.getAttribute('data-topic');
+			// No selection shows everything; otherwise show only the selected topics.
+			row.style.display = (selected.size === 0 || selected.has(topic)) ? '' : 'none';
 		});
 	}
 	filter.querySelectorAll('.topic-chip').forEach(function (chip) {
 		chip.addEventListener('click', function () {
 			var topic = chip.getAttribute('data-topic');
-			off[topic] = !off[topic];
-			chip.classList.toggle('active', !off[topic]);
-			chip.setAttribute('aria-pressed', off[topic] ? 'false' : 'true');
+			if (selected.has(topic)) {
+				selected.delete(topic);
+			} else {
+				selected.add(topic);
+			}
+			chip.classList.toggle('active', selected.has(topic));
+			chip.setAttribute('aria-pressed', selected.has(topic) ? 'true' : 'false');
 			apply();
 		});
 	});

--- a/tests/TestCase/Utility/Association/FindingTest.php
+++ b/tests/TestCase/Utility/Association/FindingTest.php
@@ -3,6 +3,7 @@
 namespace TestHelper\Test\TestCase\Utility\Association;
 
 use Cake\TestSuite\TestCase;
+use ReflectionClass;
 use TestHelper\Utility\Association\Finding;
 
 class FindingTest extends TestCase {
@@ -32,6 +33,60 @@ class FindingTest extends TestCase {
 		$finding = new Finding('Posts', Finding::DIRECTION_UNSUPPORTED, 'belongsToMany', Finding::SEVERITY_INFO, 'msg');
 
 		$this->assertSame(Finding::DIRECTION_UNSUPPORTED, $finding->topic());
+	}
+
+	/**
+	 * Every value topic() can return must have a flat-scan filter label (and vice versa).
+	 * Reflection over the LAYER_* constants guards against a new audit layer being added
+	 * without a matching topic chip - which would make those findings unfilterable.
+	 *
+	 * @return void
+	 */
+	public function testEveryTopicHasAFilterLabel() {
+		$layers = [];
+		foreach ((new ReflectionClass(Finding::class))->getConstants() as $name => $value) {
+			if (str_starts_with($name, 'LAYER_')) {
+				$layers[] = $value;
+			}
+		}
+		// topic() returns a layer for normal findings, or the unsupported direction otherwise.
+		$expectedTopics = array_merge($layers, [Finding::DIRECTION_UNSUPPORTED]);
+		sort($expectedTopics);
+
+		$labelled = array_keys(Finding::topicLabels());
+		sort($labelled);
+
+		$this->assertSame($expectedTopics, $labelled, 'Every finding topic must have exactly one flat-scan filter label (and vice versa).');
+	}
+
+	/**
+	 * The per-topic chip counts must account for every finding: with one finding of each
+	 * topic (including a mismatch, which is a constraint-layer finding), the totals across
+	 * the labelled chips must equal the finding count. A finding whose topic has no chip
+	 * (the regression we are guarding against) would drop out of this sum.
+	 *
+	 * @return void
+	 */
+	public function testTopicCountsCoverEveryFinding() {
+		$findings = [
+			new Finding('T', Finding::DIRECTION_MISMATCH, 'belongsTo', Finding::SEVERITY_ERROR, 'm', layer: Finding::LAYER_CONSTRAINT),
+			new Finding('T', Finding::DIRECTION_COLUMN_MISSING, 'belongsTo', Finding::SEVERITY_ERROR, 'm', layer: Finding::LAYER_COLUMN),
+			new Finding('T', Finding::DIRECTION_TYPE, 'belongsTo', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_TYPE),
+			new Finding('T', Finding::DIRECTION_RULE, 'hasMany', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_RULE),
+			new Finding('T', Finding::DIRECTION_INDEX, 'belongsTo', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_INDEX),
+			new Finding('T', Finding::DIRECTION_UNSUPPORTED, 'belongsToMany', Finding::SEVERITY_INFO, 'm'),
+		];
+
+		$counts = array_count_values(array_map(fn (Finding $finding): string => $finding->topic(), $findings));
+
+		$chipTotal = 0;
+		foreach (array_keys(Finding::topicLabels()) as $topic) {
+			$chipTotal += $counts[$topic] ?? 0;
+		}
+
+		$this->assertSame(count($findings), $chipTotal, 'Every finding must be counted under a labelled topic chip.');
+		// A mismatch finding is a constraint-layer topic.
+		$this->assertSame(1, $counts[Finding::LAYER_CONSTRAINT] ?? 0);
 	}
 
 }


### PR DESCRIPTION
## The bug

The flat-scan **Filter by topic** chips were added (#50) before the **cascade-rule** (#53) and **index-presence** (#58) layers. Those layers introduced two new topics — `rule` and `index` — but `scan.php` never got chips for them. So:

- `Finding::topic()` returns `rule`/`index`, the rows get `data-topic="rule"`/`"index"`, but **no chip controls them** → those findings (the index layer alone emits many) are unfilterable and always visible.
- That's why selecting "Not verifiable" still showed hundreds of rows.

Also, the chips used a **mute** model (click = hide that topic), the opposite of the "select to isolate" the label implies.

## The fix

- **`Finding::topicLabels()`** is now the single source of truth for the chips — covering every layer (`constraint`, `column`, `type`, `rule`, `index`) plus `unsupported`. The template uses it instead of a hard-coded list.
- **Select-to-isolate model**: nothing selected = all shown; selecting *Not verifiable* shows only those rows. Multi-select unions.

## Hard assertions (so it can't regress)

- `testEveryTopicHasAFilterLabel` — reflection over the `LAYER_*` constants asserts the label map covers exactly the set of possible topics. **A future audit layer added without a chip fails CI.**
- `testTopicCountsCoverEveryFinding` — with one finding of each topic (including a **mismatch**), the per-chip counts must sum to the total; an uncovered topic would drop out of the sum.
