### PR TITLE
Detail view: order groups worst-first + stop double-reporting loose unindexed columns

### DIFF
--- a/src/Controller/AssociationsController.php
+++ b/src/Controller/AssociationsController.php
@@ -93,8 +93,9 @@ class AssociationsController extends TestHelperAppController {
 		}
 
 		$grouped = $this->groupByDirection($findings);
+		$groupOrder = $this->orderedGroupDirections($grouped);
 
-		$this->set(compact('model', 'findings', 'grouped', 'includeVendor'));
+		$this->set(compact('model', 'findings', 'grouped', 'groupOrder', 'includeVendor'));
 	}
 
 	/**
@@ -156,6 +157,36 @@ class AssociationsController extends TestHelperAppController {
 			Finding::LAYER_INDEX => 'index',
 			default => in_array($finding->associationType, $this->columns, true) ? $finding->associationType : 'belongsTo',
 		};
+	}
+
+	/**
+	 * Detail-view group display order: worst-first by each group's highest severity, keeping the
+	 * semantic group order (groupByDirection's key order) as a tiebreak within a severity. This
+	 * floats a group containing a warning above info-only groups, matching the flat scan's
+	 * worst-first ordering instead of a fixed direction order.
+	 *
+	 * @param array<string, array<\TestHelper\Utility\Association\Finding>> $grouped
+	 * @return array<string>
+	 */
+	protected function orderedGroupDirections(array $grouped): array {
+		$directions = array_keys($grouped);
+		$semanticIndex = array_flip($directions);
+
+		$worst = [];
+		foreach ($grouped as $direction => $directionFindings) {
+			$rank = 0;
+			foreach ($directionFindings as $finding) {
+				$rank = max($rank, Finding::SEVERITY_RANK[$finding->severity] ?? 0);
+			}
+			$worst[$direction] = $rank;
+		}
+
+		usort(
+			$directions,
+			fn (string $a, string $b): int => ($worst[$b] <=> $worst[$a]) ?: ($semanticIndex[$a] <=> $semanticIndex[$b]),
+		);
+
+		return $directions;
 	}
 
 	/**

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -153,8 +153,14 @@ class AssociationAuditor {
 		$findings = array_merge($findings, $this->typeFindings($codeKeys, $this->preferIntegerKeys()));
 		$findings = array_merge($findings, $this->ruleFindings($codeKeys, $dbKeys));
 
-		// Index layer over every foreign-key-semantic column the audit already knows.
-		$indexCandidates = $this->indexCandidates($dbKeys, $codeKeys, $looseColumns, $indexedColumns);
+		// Index layer over every foreign-key-semantic column the audit already knows, minus the
+		// columns the loose-column layer already surfaced (indexing an unmanaged column is
+		// premature until it is established as a real foreign key).
+		$reportedLoose = $this->reportedLooseColumns($looseColumns, $codeKeys, $this->ignoreColumns(), $claimedColumns);
+		$indexCandidates = $this->dedupeIndexCandidatesAgainstLoose(
+			$this->indexCandidates($dbKeys, $codeKeys, $looseColumns, $indexedColumns),
+			$reportedLoose,
+		);
 		$findings = array_merge($findings, $this->indexFindings($indexCandidates, $indexedColumns, $this->ignoreColumns(), $checkIndexes, $aliasByPhysical));
 
 		return $findings;
@@ -323,25 +329,8 @@ class AssociationAuditor {
 	 * @return array<\TestHelper\Utility\Association\Finding>
 	 */
 	public function looseColumnFindings(array $looseColumns, array $codeKeys, array $ignoreColumns, array $aliasByPhysical = [], array $claimedColumns = []): array {
-		$claimed = [];
-		foreach ($codeKeys as $fk) {
-			foreach ($fk->columns as $column) {
-				$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $column] = true;
-			}
-		}
-		foreach ($claimedColumns as $id) {
-			$claimed[$id] = true;
-		}
-
 		$findings = [];
-		foreach ($looseColumns as $column) {
-			if (in_array($column->column, $ignoreColumns, true)) {
-				continue;
-			}
-			if (isset($claimed[$column->connection . '|' . $column->table . '|' . $column->column])) {
-				continue;
-			}
-
+		foreach ($this->reportedLooseColumns($looseColumns, $codeKeys, $ignoreColumns, $claimedColumns) as $column) {
 			$findings[] = new Finding(
 				table: $this->aliasFor($column->connection, $column->table, $aliasByPhysical),
 				direction: Finding::DIRECTION_CODE_MISSING,
@@ -358,6 +347,42 @@ class AssociationAuditor {
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * The loose `*_id` columns the loose-column layer reports: those not claimed by any
+	 * association and not in the ignore list. Returns the LooseColumn objects (which keep the
+	 * connection dimension) so callers can dedupe connection-aware, unlike the rendered findings.
+	 *
+	 * @param array<\TestHelper\Utility\Association\LooseColumn> $looseColumns
+	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
+	 * @param array<string> $ignoreColumns
+	 * @param array<string> $claimedColumns Extra `connection|table|column` ids claimed by unsupported associations.
+	 * @return array<\TestHelper\Utility\Association\LooseColumn>
+	 */
+	public function reportedLooseColumns(array $looseColumns, array $codeKeys, array $ignoreColumns, array $claimedColumns = []): array {
+		$claimed = [];
+		foreach ($codeKeys as $fk) {
+			foreach ($fk->columns as $column) {
+				$claimed[$fk->connection . '|' . $fk->ownerTable . '|' . $column] = true;
+			}
+		}
+		foreach ($claimedColumns as $id) {
+			$claimed[$id] = true;
+		}
+
+		$reported = [];
+		foreach ($looseColumns as $column) {
+			if (in_array($column->column, $ignoreColumns, true)) {
+				continue;
+			}
+			if (isset($claimed[$column->connection . '|' . $column->table . '|' . $column->column])) {
+				continue;
+			}
+			$reported[] = $column;
+		}
+
+		return $reported;
 	}
 
 	/**
@@ -668,6 +693,29 @@ class AssociationAuditor {
 		}
 
 		return $findings;
+	}
+
+	/**
+	 * Drop index candidates for columns the loose-column layer already reports: indexing a
+	 * column not yet established as a real foreign key is premature, and the two layers would
+	 * otherwise double-report the same column. Matched on connection-aware identity (not the
+	 * rendered alias), so same-named tables on different connections stay distinct.
+	 *
+	 * @param array<\TestHelper\Utility\Association\ForeignKey|\TestHelper\Utility\Association\LooseColumn> $candidates
+	 * @param array<\TestHelper\Utility\Association\LooseColumn> $reportedLoose
+	 * @return array<\TestHelper\Utility\Association\ForeignKey|\TestHelper\Utility\Association\LooseColumn>
+	 */
+	public function dedupeIndexCandidatesAgainstLoose(array $candidates, array $reportedLoose): array {
+		$looseIds = [];
+		foreach ($reportedLoose as $column) {
+			$looseIds[$column->connection . '|' . $column->table . '|' . $column->column] = true;
+		}
+
+		return array_values(array_filter($candidates, function (ForeignKey|LooseColumn $candidate) use ($looseIds): bool {
+			[$connection, $table, $column] = $this->candidateParts($candidate);
+
+			return !isset($looseIds[$connection . '|' . $table . '|' . $column]);
+		}));
 	}
 
 	/**

--- a/templates/Associations/view.php
+++ b/templates/Associations/view.php
@@ -4,6 +4,7 @@
  * @var string|null $model
  * @var array<\TestHelper\Utility\Association\Finding> $findings
  * @var array<string, array<\TestHelper\Utility\Association\Finding>> $grouped
+ * @var array<string> $groupOrder
  * @var bool $includeVendor
  */
 
@@ -42,7 +43,8 @@ $severityBadge = function (string $severity): string {
 	<div class="alert alert-success"><?php echo $this->TestHelper->icon('check'); ?> All associations agree with the database.</div>
 <?php } ?>
 
-<?php foreach ($labels as $direction => [$title, $color]) { ?>
+<?php foreach ($groupOrder as $direction) { ?>
+	<?php [$title, $color] = $labels[$direction]; ?>
 	<?php $items = $grouped[$direction] ?? []; ?>
 	<?php if (!$items) {
 		continue;

--- a/tests/TestCase/Controller/AssociationsControllerTest.php
+++ b/tests/TestCase/Controller/AssociationsControllerTest.php
@@ -63,6 +63,41 @@ class AssociationsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Detail-view groups order worst-first: a group containing a warning floats above
+	 * info-only groups, with the semantic group order kept as a tiebreak within a severity.
+	 *
+	 * @return void
+	 */
+	public function testOrderedGroupDirectionsFloatsWarningsAboveInfo() {
+		$controller = new class (new ServerRequest()) extends AssociationsController {
+
+			/**
+			 * @param array<string, array<\TestHelper\Utility\Association\Finding>> $grouped
+			 * @return array<string>
+			 */
+			public function orderedGroupDirectionsPublic(array $grouped): array {
+				return $this->orderedGroupDirections($grouped);
+			}
+
+		};
+
+		// Semantic order puts the info-only index group above the warning db-missing group.
+		$grouped = [
+			Finding::DIRECTION_INDEX => [new Finding('T', Finding::DIRECTION_INDEX, 'belongsTo', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_INDEX)],
+			Finding::DIRECTION_DB_MISSING => [new Finding('T', Finding::DIRECTION_DB_MISSING, 'belongsTo', Finding::SEVERITY_WARNING, 'm', layer: Finding::LAYER_CONSTRAINT)],
+			Finding::DIRECTION_CODE_MISSING => [new Finding('T', Finding::DIRECTION_CODE_MISSING, 'looseColumn', Finding::SEVERITY_INFO, 'm', layer: Finding::LAYER_COLUMN)],
+		];
+
+		$order = $controller->orderedGroupDirectionsPublic($grouped);
+
+		// Warning group first; the two info groups keep their semantic order behind it.
+		$this->assertSame(
+			[Finding::DIRECTION_DB_MISSING, Finding::DIRECTION_INDEX, Finding::DIRECTION_CODE_MISSING],
+			$order,
+		);
+	}
+
+	/**
 	 * The vendor toggle flows through to the view.
 	 *
 	 * @return void

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -572,6 +572,28 @@ class AssociationAuditorTest extends TestCase {
 	}
 
 	/**
+	 * An index candidate for a column already surfaced as a loose (unmanaged) column is dropped
+	 * ("add an index" is premature until it is a real FK), matched connection-aware: the same
+	 * column on another connection, and other columns, are kept.
+	 *
+	 * @return void
+	 */
+	public function testDedupeIndexCandidatesAgainstLoose() {
+		$reportedLoose = [new LooseColumn('default', 'webcal_user_media', 'unit_id')];
+		$candidates = [
+			new LooseColumn('default', 'webcal_user_media', 'unit_id'), // same identity -> dropped
+			new LooseColumn('other', 'webcal_user_media', 'unit_id'), // other connection -> kept
+			new ForeignKey('default', 'webcal_user_media', 'author_id', 'authors', 'id', ForeignKey::SOURCE_DB), // other column -> kept
+		];
+
+		$result = $this->auditor->dedupeIndexCandidatesAgainstLoose($candidates, $reportedLoose);
+
+		$this->assertCount(2, $result);
+		$connections = array_map(fn ($candidate): string => $candidate->connection, $result);
+		$this->assertContains('other', $connections);
+	}
+
+	/**
 	 * A loose column uses the "looks like a foreign key" wording.
 	 *
 	 * @return void


### PR DESCRIPTION
Two UX fixes for the per-table association detail view, surfaced from real audit output.

## Order finding groups worst-first
The detail view rendered groups in a fixed direction order, so an info-only group (`Missing indexes`) could appear above a warning group (`Declared, but missing DB constraint`) — inconsistent with the flat scan, which already sorts worst-first. Groups now order by each group's highest severity, keeping the semantic group order as a tiebreak within a severity. A group containing a warning floats above info-only groups.

## Don't double-report loose, unindexed columns
A loose `*_id` column with no constraint and no association that is also unindexed was reported by both the loose-column layer ("no constraint and no association") and the index layer ("no index"). For a column not yet established as a real foreign key, "add an index" is premature, so the index layer now drops candidates the loose-column layer already reports. The match is connection-aware (physical connection + table + column, not the rendered alias), so same-named tables on different connections stay distinct. Once such a column becomes a real FK, the index finding returns.

Both behaviors are covered by unit tests (`orderedGroupDirections`, `dedupeIndexCandidatesAgainstLoose`).