### PR TITLE
Association audit: let ignoreColumns suppress key-type findings

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -136,7 +136,7 @@ problems:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `TestHelper.associationAudit.ignoreColumns` | `[]` | Extra `*_id` column names to ignore in the loose-column layer (merged with the built-in polymorphic defaults). |
+| `TestHelper.associationAudit.ignoreColumns` | `[]` | Column names to skip in the loose-column **and** key-type layers (merged with the built-in polymorphic defaults). Use for deliberately polymorphic string keys such as FileStorage's `foreign_key`, which legitimately holds integer owner ids. |
 | `TestHelper.associationAudit.preferIntegerKeys` | `true` | When `false`, suppress the "integer keys are preferred" info hint. Type-family errors and narrowing warnings still report. |
 | `TestHelper.associationAudit.checkIndexes` | `true` | When `false`, disable the index-presence layer entirely (no "foreign key with no index" info findings). |
 

--- a/src/Utility/Association/AssociationAuditor.php
+++ b/src/Utility/Association/AssociationAuditor.php
@@ -150,7 +150,7 @@ class AssociationAuditor {
 
 		$findings = array_merge($findings, $this->diffForeignKeys($codeKeys, $dbKeys, $aliasByPhysical));
 		$findings = array_merge($findings, $this->looseColumnFindings($looseColumns, $codeKeys, $this->ignoreColumns(), $aliasByPhysical, $claimedColumns));
-		$findings = array_merge($findings, $this->typeFindings($codeKeys, $this->preferIntegerKeys()));
+		$findings = array_merge($findings, $this->typeFindings($codeKeys, $this->preferIntegerKeys(), $this->ignoreColumns()));
 		$findings = array_merge($findings, $this->ruleFindings($codeKeys, $dbKeys));
 
 		// Index layer over every foreign-key-semantic column the audit already knows, minus the
@@ -399,9 +399,12 @@ class AssociationAuditor {
 	 * @param array<\TestHelper\Utility\Association\ForeignKey> $codeKeys
 	 * @param bool|null $preferIntegerKeys When false, the non-integer info advisory is suppressed
 	 *   (errors remain); null falls back to the `TestHelper.associationAudit.preferIntegerKeys` config.
+	 * @param array<string> $ignoreColumns Owner columns to skip entirely (no type finding of any
+	 *   severity). Use for deliberately polymorphic keys such as FileStorage's `foreign_key`, a
+	 *   string column that legitimately holds integer owner ids.
 	 * @return array<\TestHelper\Utility\Association\Finding>
 	 */
-	public function typeFindings(array $codeKeys, ?bool $preferIntegerKeys = null): array {
+	public function typeFindings(array $codeKeys, ?bool $preferIntegerKeys = null, array $ignoreColumns = []): array {
 		$preferIntegerKeys ??= $this->preferIntegerKeys();
 		$seen = [];
 		$findings = [];
@@ -415,6 +418,12 @@ class AssociationAuditor {
 				continue;
 			}
 			$seen[$fk->key()] = true;
+
+			// Deliberately polymorphic keys (e.g. FileStorage's string `foreign_key` holding
+			// integer owner ids) are opted out of type comparison via the ignore list.
+			if (in_array($fk->column, $ignoreColumns, true)) {
+				continue;
+			}
 
 			$ownerBucket = $this->typeBucket($fk->ownerColumnType);
 			$referencedBucket = $this->typeBucket($fk->referencedColumnType);

--- a/tests/TestCase/Utility/Association/AssociationAuditorTest.php
+++ b/tests/TestCase/Utility/Association/AssociationAuditorTest.php
@@ -357,6 +357,18 @@ class AssociationAuditorTest extends TestCase {
 	}
 
 	/**
+	 * A type mismatch on an ignored owner column is suppressed entirely (no finding of any
+	 * severity). Used for deliberately polymorphic keys such as FileStorage's `foreign_key`.
+	 *
+	 * @return void
+	 */
+	public function testTypeMismatchIgnoredColumn() {
+		$findings = $this->auditor->typeFindings([$this->typedKey('integer', 'uuid')], null, ['author_id']);
+
+		$this->assertSame([], $findings);
+	}
+
+	/**
 	 * A type mismatch carries a changeColumn fix aligning the FK column to its target.
 	 *
 	 * @return void


### PR DESCRIPTION
## What

The association audit's **key-type layer** flags FK columns whose type family differs from the referenced key (e.g. `integer` referencing `uuid`) as a hard error. Deliberately polymorphic string keys — most notably FileStorage's `char(36)` `foreign_key`, which legitimately stores integer owner ids — therefore always errored, with no opt-out.

## Change

`typeFindings()` now skips owner columns listed in `TestHelper.associationAudit.ignoreColumns` (the same config the loose-column layer already honors), and `audit()` passes the configured list through. So:

```php
Configure::write('TestHelper.associationAudit.ignoreColumns', ['foreign_key']);
```

silences both the loose-column and the key-type finding for that column.

## Tests / docs

- Added `testTypeMismatchIgnoredColumn`; full suite green (374 tests), phpcs + phpstan clean.
- Updated the config table in `docs/associations.md`.
